### PR TITLE
docs: fix linking

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,13 +125,16 @@ myst_enable_extensions = [
     "strikethrough",
     "substitution",
     "tasklist",
+    "attrs_inline",
+    "attrs_block",
 ]
 
 suppress_warnings = ["myst.header"]
 
-myst_gfm_only = True
+myst_gfm_only = False
 myst_heading_anchors = 1
 myst_title_to_header = True
+
 
 # app setup hook
 def setup(app):

--- a/docs/getting_started/quickstart_cn.md
+++ b/docs/getting_started/quickstart_cn.md
@@ -6,8 +6,8 @@
 
 在部署时有两种组网模式可供选择：
 
-- [中心化组网模式](../reference/architecture_cn.html#id7)：启动一个控制平面（master）容器和两个 Lite 节点（alice 和 bob）容器
-- [点对点组网模式](../reference/architecture_cn.html#id8)：启动两个 Autonomy 节点（alice 和 bob）容器
+- [中心化组网模式](../reference/architecture_cn.md#centralized)：启动一个控制平面（master）容器和两个 Lite 节点（alice 和 bob）容器
+- [点对点组网模式](../reference/architecture_cn.md#peer-to-peer)：启动两个 Autonomy 节点（alice 和 bob）容器
 
 你可以选择其中任意一种或两种模式进行部署体验，在单台机器上可以同时部署两种模式。
 
@@ -114,11 +114,8 @@ K400,F,FFF
 K500,G,GGG
 ```
 
-
-
 ## 接下来
 
-如果你希望使用自己的数据来执行作业，请参考[如何运行一个 Secretflow 任务](../tutorial/run_secretflow_cn.html)。
+如果你希望使用自己的数据来执行作业，请参考[如何运行一个 Secretflow 任务](../tutorial/run_secretflow_cn.md)。
 
-如果你希望体验在安全沙箱中执行作业，请参考[如何启用安全沙箱](../tutorial/enable_security_sandbox_cn.html)。
-
+如果你希望体验在安全沙箱中执行作业，请参考[如何启用安全沙箱](../tutorial/security_plan_cn.md)。

--- a/docs/reference/architecture_cn.md
+++ b/docs/reference/architecture_cn.md
@@ -12,7 +12,7 @@ Kuscia 支持 Lite 节点与 Autonomy 节点、以及两个中心化网络互联
 
 ![Deployment Mode](../imgs/linkaged_network.png)
 
-## Kuscia组件
+## Kuscia 组件
 
 ### 控制平面
 
@@ -97,12 +97,16 @@ Data Proxy 主要用于数据代理，为应用屏蔽异构数据源的差异，
 
 Kuscia 支持两种组网模式：中心化组网模式和点对点组网模式。
 
+{#centralized}
+
 ### 中心化组网模式
 
 中心化组网模式下，多个节点共享控制平面，控制平面负责管理多个节点的资源和任务调度。这种模式下节点占用资源较少，称为 Lite 节点。
 中心化组网模式适合于大型机构内部的节点互联，通过统一的控制平面，可显著降低运维和资源成本，且便于快速新增节点。
 
 ![Centralized Network Mode](../imgs/centralized_network_mode.png)
+
+{#peer-to-peer}
 
 ### 点对点组网模式
 

--- a/docs/reference/operation_cn.md
+++ b/docs/reference/operation_cn.md
@@ -14,8 +14,7 @@ docker ps -a
 - bob 节点容器
 - master 容器
 
-[//]: # (开源容器镜像地址替换)
-
+[//]: # '开源容器镜像地址替换'
 
 在中心化组网模式下会有单独的 master 容器：
 
@@ -100,7 +99,7 @@ kubectl get crd | grep kuscia.secretflow
 我们以 KusciaJob 为例：
 
 ```shell
-kubectl explain kj 
+kubectl explain kj
 ```
 
 或者
@@ -111,7 +110,7 @@ kubectl get crd kusciajobs.kuscia.secretflow -o yaml
 
 ##### 更多 Kubectl 使用
 
-如果你想了解 kubectl 命令的使用，你可以查阅 [Kubernetes官方文档](https://kubernetes.io/zh-cn/docs/reference/kubectl/) 。
+如果你想了解 kubectl 命令的使用，你可以查阅 [Kubernetes 官方文档](https://kubernetes.io/zh-cn/docs/reference/kubectl/) 。
 
 ### Domain
 
@@ -148,15 +147,15 @@ spec:
   cert: { cert_data }
 status:
   nodeStatuses:
-    - lastHeartbeatTime: "2023-04-04T08:47:56Z"
-      lastTransitionTime: "2023-03-30T09:44:45Z"
+    - lastHeartbeatTime: '2023-04-04T08:47:56Z'
+      lastTransitionTime: '2023-03-30T09:44:45Z'
       name: 9c3ee316d37e
       status: Ready
       version: a50f56e-a50f56e
 ```
 
 其中，我们需要关注`.status.nodeStatuses[].status`，这个字段记录了 Domain 下的节点是否正常。 有关 Domain
-的更多信息，请查看 [Domain](./concepts/domain_cn.html) 。
+的更多信息，请查看 [Domain](./concepts/domain_cn.md) 。
 
 ### DomainRoute
 
@@ -202,7 +201,7 @@ kubectl get dr {domain_router_name} -o yaml -n {domain_name}
 kubectl get dr alice-bob -o yaml -n alice
 ```
 
-有关 DomainRoute 的更多信息，请查看 [DomainRoute](./concepts/domainroute_clusterdomainroute_cn.html) 。
+有关 DomainRoute 的更多信息，请查看 [DomainRoute](./concepts/domainroute_cn.md) 。
 
 ### AppImage
 
@@ -228,12 +227,12 @@ kubectl get aimg {aimg-name} -o yaml
 kubectl get aimg secretflow-image -o yaml
 ```
 
-有关 AppImage 的更多信息，请查看 [AppImage](./concepts/appimage_cn.html) 。
+有关 AppImage 的更多信息，请查看 [AppImage](./concepts/appimage_cn.md) 。
 
 ### KusciaJob & KusciaTask
 
-关于如何配置、运行和查看 KusciaJob 和 KusciaTask，请参考 [如何运行一个 secretflow 任务](../tutorial/run_secretflow_cn.html)
-和 [KusciaJob](./concepts/kusciajob_cn.html) 。
+关于如何配置、运行和查看 KusciaJob 和 KusciaTask，请参考 [如何运行一个 secretflow 任务](../tutorial/run_secretflow_cn.md)
+和 [KusciaJob](./concepts/kusciajob_cn.md) 。
 
 ## 节点容器
 
@@ -246,7 +245,7 @@ docker exec -it ${USER}-kuscia-lite-alice bash
 ### 隐私计算任务
 
 隐私计算任务将会以容器的形式在 节点容器 内部运行。以 alice 节点容器为例，每当一个新的隐私计算任务分派到 alice 节点时，alice 节点容器都会启动一个容器来处理任务。
-这是一个容器嵌套容器的形式：宿主机上通过docker启动了 alice 节点容器，而在 alice 节点容器中，通过 crictl 启动了任务容器，理解这一点非常重要。
+这是一个容器嵌套容器的形式：宿主机上通过 docker 启动了 alice 节点容器，而在 alice 节点容器中，通过 crictl 启动了任务容器，理解这一点非常重要。
 
 #### 查看当前 Lite 节点上正在进行的任务
 
@@ -282,5 +281,7 @@ crictl exec -it {container_id} bash
 3. 进入任务容器，执行原来的 command 进行调试操作。
 
 ## 安全建议
+
 ### Envoy
+
 Envoy 的 Admin 端口仅用于本地监听，请勿将 Admin 端口暴露在非安全的网络中，防止信息泄露。

--- a/docs/tutorial/run_secretflow_cn.md
+++ b/docs/tutorial/run_secretflow_cn.md
@@ -2,7 +2,7 @@
 
 ## 准备节点
 
-准备节点包含部署节点和创建授权两个步骤，请参考[快速入门](../getting_started/quickstart_cn.html) .
+准备节点包含部署节点和创建授权两个步骤，请参考[快速入门](../getting_started/quickstart_cn.md) .
 
 ## 准备数据
 
@@ -10,39 +10,47 @@
 
 在 Kuscia 中， 节点数据文件的存放路径为节点容器的`/home/kuscia/var/storage`，你可以在容器中查看这个数据文件。
 
-### 查看Kuscia示例数据
+### 查看 Kuscia 示例数据
 
 这里以 alice 节点为例，首先进入节点容器：
+
 ```shell
 docker exec -it ${USER}-kuscia-lite-alice bash
 ```
 
 在 alice 节点容器中查看节点示例数据：
+
 ```shell
 cat /home/kuscia/var/storage/data/alice.csv
 ```
 
 bob 节点同理。
 
+{#prepare-your-own-data}
+
 ### 准备你自己的数据
 
 你也可以使用你自己的数据文件，首先你要你的数据文件复制到节点容器中，还是以 alice 节点为例：
+
 ```shell
 docker cp {your_alice_data} ${USER}-kuscia-lite-alice:/home/kuscia/var/storage/data/
 ```
 
-接下来你可以像 [查看Kuscia示例数据](#kuscia) 一样查看你的数据文件，这里不再赘述。
+接下来你可以像 [查看 Kuscia 示例数据](#kuscia) 一样查看你的数据文件，这里不再赘述。
+
+{#configure-kuscia-job}
 
 ## 配置 KusciaJob
 
 我们需要在 kuscia-master 节点容器中配置和运行 Job，首先，让我们先进入 kuscia-master 节点容器：
+
 ```shell
 docker exec -it ${USER}-kuscia-master bash
 ```
 
 ### 使用 Kuscia 示例数据配置 KusciaJob
 
-下面的示例展示了一个 KusciaJob， 该任务流完成2个任务：
+下面的示例展示了一个 KusciaJob， 该任务流完成 2 个任务：
 
 1. job-psi 读取 alice 和 bob 的数据文件，进行隐私求交，求交的结果分别保存为两个参与方的`psi_out.csv`。
 2. job-split 读取 alice 和 bob 上一步中求交的结果文件，并拆分成训练集和测试集，分别保存为两个参与方的`train_dataset.csv`、`test_dataset.csv`。
@@ -50,6 +58,7 @@ docker exec -it ${USER}-kuscia-master bash
 这个 KusciaJob 的名称为 job-best-effort-linear，在一个 Kuscia 集群中，这个名称必须是唯一的，由`.metadata.name`指定。
 
 在 kuscia-master 容器中，在任意路径创建文件 job-best-effort-linear.yaml，内容如下：
+
 ```yaml
 apiVersion: kuscia.secretflow/v1alpha1
 kind: KusciaJob
@@ -69,7 +78,7 @@ spec:
         - domainID: bob
     - taskID: job-split
       priority: 100
-      dependencies: [ "job-psi" ]
+      dependencies: ['job-psi']
       taskInputConfig: '{"sf_storage_config":{"alice":{"type":"local_fs","local_fs":{"wd":"/home/kuscia/var/storage/data"}},"bob":{"type":"local_fs","local_fs":{"wd":"/home/kuscia/var/storage/data"}}},"sf_cluster_desc":{"parties":["alice","bob"],"devices":[{"name":"spu","type":"spu","parties":["alice","bob"],"config":"{\\\"runtime_config\\\":{\\\"protocol\\\":\\\"REF2K\\\",\\\"field\\\":\\\"FM64\\\"},\\\"link_desc\\\":{\\\"connect_retry_times\\\":60,\\\"connect_retry_interval_ms\\\":1000,\\\"brpc_channel_protocol\\\":\\\"http\\\",\\\"brpc_channel_connection_type\\\":\\\"pooled\\\",\\\"recv_timeout_ms\\\":1200000,\\\"http_timeout_ms\\\":1200000}}"},{"name":"heu","type":"heu","parties":["alice","bob"],"config":"{\\\"mode\\\": \\\"PHEU\\\", \\\"schema\\\": \\\"paillier\\\", \\\"key_size\\\": 2048}"}]},"sf_node_eval_param":{"domain":"preprocessing","name":"train_test_split","version":"0.0.1","attr_paths":["train_size","test_size","random_state","shuffle"],"attrs":[{"f":0.75},{"f":0.25},{"i64":1234},{"b":true}],"inputs":[{"type":"sf.table.vertical_table","meta":{"@type":"type.googleapis.com/secretflow.component.VerticalTable","schemas":[{"ids":["id1"],"features":["item","feature1"],"types":["f32","f32"],"labels":["y"]},{"ids":["id2"],"features":["feature2"],"types":["f32"]}]},"data_refs":[{"uri":"psi_out.csv","party":"alice","format":"csv"},{"uri":"psi_out.csv","party":"bob","format":"csv"}]}],"output_uris":["train_dataset.csv","test_dataset.csv"]}}'
       appImage: secretflow-image
       parties:
@@ -79,16 +88,17 @@ spec:
 
 ### 使用你自己的数据配置 KusciaJob
 
-如果你要使用你自己的数据，可以将两个算子中的`taskInputConfig.sf_node_eval_param`中的`inputs`和`output_uris`中的数据文件路径修改为你在 [准备你自己的数据](#id3) 中的数据文件目标路径即可。
+如果你要使用你自己的数据，可以将两个算子中的`taskInputConfig.sf_node_eval_param`中的`inputs`和`output_uris`中的数据文件路径修改为你在 [准备你自己的数据](#prepare-your-own-data) 中的数据文件目标路径即可。
 
 ### 更多相关
 
-更多有关 KusciaJob 配置的信息，请查看 [KusciaJob](../reference/concepts/kusciajob_cn.html) 和 [算子参数描述](#id11) 。
+更多有关 KusciaJob 配置的信息，请查看 [KusciaJob](../reference/concepts/kusciajob_cn.md) 和 [算子参数描述](#input-config) 。
 前者描述了 KusciaJob 的定义和相关说明，后者描述了支持的算子和参数。
 
 ## 运行 KusciaJob
 
 现在我们已经配置好了一个 KusciaJob ，接下来，让我们运行这个 KusciaJob， 在 kuscia-master 容器中执行 ：
+
 ```shell
 kubectl apply -f job-best-effort-linear.yaml
 ```
@@ -98,22 +108,30 @@ kubectl apply -f job-best-effort-linear.yaml
 现在我们提交了这个 KusciaJob ，接下来我们可以在 kuscia-master 容器中通过下面的命令查看 KusciaJob 的运行情况。
 
 ### 查看所有的 KusciaJob
+
 ```shell
 kubectl get kj
 ```
+
 你可以看到如下输出：
+
 ```shell
 NAME                     STARTTIME   COMPLETIONTIME   LASTRECONCILETIME   PHASE
 job-best-effort-linear   3s                           3s                  Running
 ```
+
 job-best-effort-linear 就是我们刚刚创建出来的 KusciaJob 。
 
 ### 查看运行中的某个 KusciaJob 的详细状态
-通过指定`-o yaml`参数，我们可以以 Yaml 的形式看到 KusciaJob 的详细状态。job-best-effort-linear 是你在 [配置Job](#配置Job) 中指定的 KusciaJob 的名称。
+
+通过指定`-o yaml`参数，我们可以以 Yaml 的形式看到 KusciaJob 的详细状态。job-best-effort-linear 是你在 [配置 Job](#configure-kuscia-job) 中指定的 KusciaJob 的名称。
+
 ```shell
 kubectl get kj job-best-effort-linear -o yaml
 ```
+
 如果任务成功了，你可以看到如下输出：
+
 ```shell
 apiVersion: kuscia.secretflow/v1alpha1
 kind: KusciaJob
@@ -155,22 +173,31 @@ status:
     job-psi: Succeeded
     job-split: Succeeded
 ```
+
 `status`字段记录了 KusciaJob 的运行状态，`.status.phase`字段描述了 KusciaJob 的整体状态，而 `.status.taskStatus`则描述了每个 KusciaTask 的状态。
-详细信息请参考 [KusciaJob](../reference/concepts/kusciajob_cn.html) 。
+详细信息请参考 [KusciaJob](../reference/concepts/kusciajob_cn.md) 。
 
 ### 查看 KusciaJob 中的某个 KusciaTask 的详细状态。
+
 KusciaJob 中的每一个 KusciaTask 都有一个`taskID`，通过`taskID`我们可以查看某个 KusciaTask 的详细状态。
+
 ```shell
 kubectl get kt job-psi -o yaml
 ```
-KusciaTask 的信息这里不再赘述，请查看 [KusciaTask](../reference/concepts/kusciatask_cn.html) 。
+
+KusciaTask 的信息这里不再赘述，请查看 [KusciaTask](../reference/concepts/kusciatask_cn.md) 。
 
 ## 删除 KusciaJob
+
 当你想取消或者清理这个 KusciaJob 时，你可以通过下面的命令完成：
+
 ```shell
 kubectl delete kj job-best-effort-linear
 ```
+
 当这个 KusciaJob 被清理时， 这个 KusciaJob 创建的 KusciaTask 也会一起被清理。
+
+{#input-config}
 
 ## 算子参数描述
 
@@ -178,7 +205,7 @@ KusciaJob 的算子参数由`taskInputConfig`字段定义，对于不同的算�
 
 下面是一个隐私求交的算子示例。
 
-### TaskInputConfig结构示例和定义
+### TaskInputConfig 结构示例和定义
 
 #### 示例
 
@@ -199,18 +226,12 @@ KusciaJob 的算子参数由`taskInputConfig`字段定义，对于不同的算�
     }
   },
   "sf_cluster_desc": {
-    "parties": [
-      "alice",
-      "bob"
-    ],
+    "parties": ["alice", "bob"],
     "devices": [
       {
         "name": "spu",
         "type": "spu",
-        "parties": [
-          "alice",
-          "bob"
-        ],
+        "parties": ["alice", "bob"],
         "config": "{\"runtime_config\":{\"protocol\":\"REF2K\",\"field\":\"FM64\"},\"link_desc\":{\"connect_retry_times\":60,\"connect_retry_interval_ms\":1000,\"brpc_channel_protocol\":\"http\",\"brpc_channel_connection_type\":\"pooled\",\"recv_timeout_ms\":1200000,\"http_timeout_ms\":1200000}}"
       }
     ]
@@ -253,14 +274,10 @@ KusciaJob 的算子参数由`taskInputConfig`字段定义，对于不同的算�
         "s": "CURVE_FOURQ"
       },
       {
-        "ss": [
-          "id1"
-        ]
+        "ss": ["id1"]
       },
       {
-        "ss": [
-          "id2"
-        ]
+        "ss": ["id2"]
       }
     ],
     "inputs": [
@@ -276,16 +293,8 @@ KusciaJob 的算子参数由`taskInputConfig`字段定义，对于不同的算�
         "meta": {
           "@type": "type.googleapis.com/secretflow.component.IndividualTable",
           "schema": {
-            "types": [
-              "str",
-              "str",
-              "str"
-            ],
-            "features": [
-              "id1",
-              "item",
-              "feature1"
-            ]
+            "types": ["str", "str", "str"],
+            "features": ["id1", "item", "feature1"]
           }
         }
       },
@@ -301,77 +310,69 @@ KusciaJob 的算子参数由`taskInputConfig`字段定义，对于不同的算�
         "meta": {
           "@type": "type.googleapis.com/secretflow.component.IndividualTable",
           "schema": {
-            "types": [
-              "str",
-              "str"
-            ],
-            "features": [
-              "id2",
-              "feature2"
-            ]
+            "types": ["str", "str"],
+            "features": ["id2", "feature2"]
           }
         }
       }
     ],
-    "output_uris": [
-      "psi_output.csv"
-    ]
+    "output_uris": ["psi_output.csv"]
   }
 }
 ```
 
-#### TaskInputConfig字段说明
+#### TaskInputConfig 字段说明
 
 - `sf_storage_config`描述了两方数据存放的位置。
 - `sf_cluster_desc`描述了 secretflow 参与方和集群信息。
 - `sf_node_eval_param`描述了一个 Task 中的任务参数，其中`domain`、`name`、`version`确定一个算子及其版本。
 
-##### sf_storage_config字段
+##### sf_storage_config 字段
 
-sf_storage_config字段是一个map结构，其中key标识party，value的字段描述如下：
+sf_storage_config 字段是一个 map 结构，其中 key 标识 party，value 的字段描述如下：
 
-| 参数名称        | 类型      | 描述                     |
-|-------------|---------|------------------------|
+| 参数名称    | 类型    | 描述                                |
+| ----------- | ------- | ----------------------------------- |
 | type        | string  | 数据配置类型，目前仅支持： local_fs |
-| local_fs    | object  | local_fs类型的配置信息        |
-| local_fs.wd | integer | 工作目录                   |
+| local_fs    | object  | local_fs 类型的配置信息             |
+| local_fs.wd | integer | 工作目录                            |
 
-##### sf_cluster_desc字段
+##### sf_cluster_desc 字段
 
-sf_storage_config字段是一个map结构，其中key标识party，value的字段描述如下：
+sf_storage_config 字段是一个 map 结构，其中 key 标识 party，value 的字段描述如下：
 
-| 参数名称    | 类型    | 描述                |
-|---------|-------|-------------------|
-| parties | array | 参与方列表             |
-| devices | array | secretflow 集群配置信息 |
+| 参数名称 | 类型  | 描述                    |
+| -------- | ----- | ----------------------- |
+| parties  | array | 参与方列表              |
+| devices  | array | secretflow 集群配置信息 |
 
-##### sf_node_eval_param字段
+##### sf_node_eval_param 字段
 
-| 参数名称                          | 类型      | 描述                                     |
-|-------------------------------|---------|----------------------------------------|
-| domain                        | string  | 算子的Namespace                           |
-| name                          | string  | 算子名称，和domain一起唯一确定一个算子                 |
-| version                       | integer | 算子的版本                                  |
-| attr_paths                    | array   | 参数列表，和attr按数组位置对应                      |
-| attr                          | array   | 参数值，和attr_paths按数组位置对应                 |
-| inputs                        | array   | 任务输入                                   |
-| inputs[].type                 | string  | 任务输入的类型                                |
-| inputs[].data_refs            | object  | 任务输入数据引用                               |
-| inputs[].data_refs.party      | string  | 任务输入参与方，会使用这个值指向sf_storage_config的数据配置 |
-| inputs[].data_refs.uri        | string  | 任务输入数据相对sf_storage_config的位置           |
-| inputs[].data_refs.format     | string  | 任务输入数据格式                               |
-| inputs[].meta                 | object  | 任务输入数据元信息                              |
-| inputs[].meta.@type           | string  | 任务输入数据类型                               |
-| inputs[].meta.schema          | object  | 任务输入数据模式信息                             |
-| inputs[].meta.schema.types    | array   | 任务输入数据列类型                              |
-| inputs[].meta.schema.features | array   | 任务输入数据列名                               |
-| inputs[].meta.schema.ids      | array   | 任务输入数据id列，在多方表中作为关联列                   |
-| inputs[].meta.schema.labels   | array   | 任务输入数据label列，在模型训练和预测中用作标签             |
-| output_uris                   | array   | 任务输出列表，输出会保存在sf_storage_config的数据配置中   |
+| 参数名称                      | 类型    | 描述                                                          |
+| ----------------------------- | ------- | ------------------------------------------------------------- |
+| domain                        | string  | 算子的 Namespace                                              |
+| name                          | string  | 算子名称，和 domain 一起唯一确定一个算子                      |
+| version                       | integer | 算子的版本                                                    |
+| attr_paths                    | array   | 参数列表，和 attr 按数组位置对应                              |
+| attr                          | array   | 参数值，和 attr_paths 按数组位置对应                          |
+| inputs                        | array   | 任务输入                                                      |
+| inputs[].type                 | string  | 任务输入的类型                                                |
+| inputs[].data_refs            | object  | 任务输入数据引用                                              |
+| inputs[].data_refs.party      | string  | 任务输入参与方，会使用这个值指向 sf_storage_config 的数据配置 |
+| inputs[].data_refs.uri        | string  | 任务输入数据相对 sf_storage_config 的位置                     |
+| inputs[].data_refs.format     | string  | 任务输入数据格式                                              |
+| inputs[].meta                 | object  | 任务输入数据元信息                                            |
+| inputs[].meta.@type           | string  | 任务输入数据类型                                              |
+| inputs[].meta.schema          | object  | 任务输入数据模式信息                                          |
+| inputs[].meta.schema.types    | array   | 任务输入数据列类型                                            |
+| inputs[].meta.schema.features | array   | 任务输入数据列名                                              |
+| inputs[].meta.schema.ids      | array   | 任务输入数据 id 列，在多方表中作为关联列                      |
+| inputs[].meta.schema.labels   | array   | 任务输入数据 label 列，在模型训练和预测中用作标签             |
+| output_uris                   | array   | 任务输出列表，输出会保存在 sf_storage_config 的数据配置中     |
 
-##### attr结构
+##### attr 结构
 
-Atomic类型用于泛化的参数值，对于不同的数据类型，请使用不同的字段，其中`s`、`i64`、`f`、`b`分别表示 string 、 integer 、 float 和
+Atomic 类型用于泛化的参数值，对于不同的数据类型，请使用不同的字段，其中`s`、`i64`、`f`、`b`分别表示 string 、 integer 、 float 和
 bool 类型。
 而`ss`、`i64s`、`fs`、`bs`则表示上述类型的列表。
 
@@ -381,18 +382,10 @@ bool 类型。
   "i64": 123,
   "f": 12.3,
   "b": true,
-  "ss": [
-    "a"
-  ],
-  "i64s": [
-    1
-  ],
-  "fs": [
-    1.0
-  ],
-  "bs": [
-    true
-  ]
+  "ss": ["a"],
+  "i64s": [1],
+  "fs": [1.0],
+  "bs": [true]
 }
 ```
 
@@ -419,18 +412,12 @@ bool 类型。
     }
   },
   "sf_cluster_desc": {
-    "parties": [
-      "alice",
-      "bob"
-    ],
+    "parties": ["alice", "bob"],
     "devices": [
       {
         "name": "spu",
         "type": "spu",
-        "parties": [
-          "alice",
-          "bob"
-        ],
+        "parties": ["alice", "bob"],
         "config": "{\"runtime_config\":{\"protocol\":\"REF2K\",\"field\":\"FM64\"},\"link_desc\":{\"connect_retry_times\":60,\"connect_retry_interval_ms\":1000,\"brpc_channel_protocol\":\"http\",\"brpc_channel_connection_type\":\"pooled\",\"recv_timeout_ms\":1200000,\"http_timeout_ms\":1200000}}"
       }
     ]
@@ -473,14 +460,10 @@ bool 类型。
         "s": "CURVE_FOURQ"
       },
       {
-        "ss": [
-          "id1"
-        ]
+        "ss": ["id1"]
       },
       {
-        "ss": [
-          "id2"
-        ]
+        "ss": ["id2"]
       }
     ],
     "inputs": [
@@ -496,16 +479,8 @@ bool 类型。
         "meta": {
           "@type": "type.googleapis.com/secretflow.component.IndividualTable",
           "schema": {
-            "types": [
-              "str",
-              "str",
-              "str"
-            ],
-            "features": [
-              "id1",
-              "item",
-              "feature1"
-            ]
+            "types": ["str", "str", "str"],
+            "features": ["id1", "item", "feature1"]
           }
         }
       },
@@ -521,36 +496,28 @@ bool 类型。
         "meta": {
           "@type": "type.googleapis.com/secretflow.component.IndividualTable",
           "schema": {
-            "types": [
-              "str",
-              "str"
-            ],
-            "features": [
-              "id2",
-              "feature2"
-            ]
+            "types": ["str", "str"],
+            "features": ["id2", "feature2"]
           }
         }
       }
     ],
-    "output_uris": [
-      "psi_output.csv"
-    ]
+    "output_uris": ["psi_output.csv"]
   }
 }
 ```
 
 参数如下：
 
-| 参数名称             | 类型      | 描述              |
-|------------------|---------|-----------------|
-| protocol         | string  | PSI协议           |
-| receiver         | string  | 哪方获得求交数据        |
-| precheck_input   | bool    | 求交前是否检查数据       |
-| sort             | bool    | 求交后是否排序         |
+| 参数名称         | 类型    | 描述                        |
+| ---------------- | ------- | --------------------------- |
+| protocol         | string  | PSI 协议                    |
+| receiver         | string  | 哪方获得求交数据            |
+| precheck_input   | bool    | 求交前是否检查数据          |
+| sort             | bool    | 求交后是否排序              |
 | broadcast_result | bool    | 是否将求交结果广播给各方    |
-| bucket_size      | integer | 指定在PSI中的hash桶大小 |
-| curve_type       | string  | ECDH PSI的曲线类型   |
+| bucket_size      | integer | 指定在 PSI 中的 hash 桶大小 |
+| curve_type       | string  | ECDH PSI 的曲线类型         |
 
 #### 随机分割
 
@@ -573,27 +540,18 @@ bool 类型。
     }
   },
   "sf_cluster_desc": {
-    "parties": [
-      "alice",
-      "bob"
-    ],
+    "parties": ["alice", "bob"],
     "devices": [
       {
         "name": "spu",
         "type": "spu",
-        "parties": [
-          "alice",
-          "bob"
-        ],
+        "parties": ["alice", "bob"],
         "config": "{\"runtime_config\":{\"protocol\":\"REF2K\",\"field\":\"FM64\"},\"link_desc\":{\"connect_retry_times\":60,\"connect_retry_interval_ms\":1000,\"brpc_channel_protocol\":\"http\",\"brpc_channel_connection_type\":\"pooled\",\"recv_timeout_ms\":1200000,\"http_timeout_ms\":1200000}}"
       },
       {
         "name": "heu",
         "type": "heu",
-        "parties": [
-          "alice",
-          "bob"
-        ],
+        "parties": ["alice", "bob"],
         "config": "{\"mode\": \"PHEU\", \"schema\": \"paillier\", \"key_size\": 2048}"
       }
     ]
@@ -602,12 +560,7 @@ bool 类型。
     "domain": "preprocessing",
     "name": "train_test_split",
     "version": "0.0.1",
-    "attr_paths": [
-      "train_size",
-      "test_size",
-      "random_state",
-      "shuffle"
-    ],
+    "attr_paths": ["train_size", "test_size", "random_state", "shuffle"],
     "attrs": [
       {
         "f": 0.75
@@ -629,31 +582,15 @@ bool 类型。
           "@type": "type.googleapis.com/secretflow.component.VerticalTable",
           "schemas": [
             {
-              "ids": [
-                "id1"
-              ],
-              "features": [
-                "item",
-                "feature1"
-              ],
-              "types": [
-                "f32",
-                "f32"
-              ],
-              "labels": [
-                "y"
-              ]
+              "ids": ["id1"],
+              "features": ["item", "feature1"],
+              "types": ["f32", "f32"],
+              "labels": ["y"]
             },
             {
-              "ids": [
-                "id2"
-              ],
-              "features": [
-                "feature2"
-              ],
-              "types": [
-                "f32"
-              ]
+              "ids": ["id2"],
+              "features": ["feature2"],
+              "types": ["f32"]
             }
           ]
         },
@@ -671,19 +608,16 @@ bool 类型。
         ]
       }
     ],
-    "output_uris": [
-      "train_dataset.csv",
-      "test_dataset.csv"
-    ]
+    "output_uris": ["train_dataset.csv", "test_dataset.csv"]
   }
 }
 ```
 
 参数如下：
 
-| 参数名称         | 类型      | 描述    |
-|--------------|---------|-------|
+| 参数名称     | 类型    | 描述       |
+| ------------ | ------- | ---------- |
 | train_size   | float   | 训练集占比 |
 | test_size    | float   | 测试集占比 |
-| random_state | integer | 随机种子  |
-| shuffle      | bool    | 是否清洗  |
+| random_state | integer | 随机种子   |
+| shuffle      | bool    | 是否清洗   |

--- a/docs/tutorial/security_plan_cn.md
+++ b/docs/tutorial/security_plan_cn.md
@@ -2,15 +2,13 @@
 
 ## 说明
 
-在面对不可知任务场景或未知代码执行的场景中，建议使用进程安全沙箱 [NsJail](https://github.com/google/nsjail) 保障运行时安全以及使用安全容器 [Kata](https://github.com/kata-containers/kata-containers) 保障容器安全。
+在面对不可知任务场景或未知代码执行的场景中，建议使用进程安全沙箱 [NsJail](https://github.com/google/nsjail) 保障运行时安全以及使用安全容器 [Kata](https://github.com/kata-containers/kata-containers)  保障容器安全。
 
 Secretflow 支持通过 NsJail 启动，这使得 Secretflow 任务可以在安全沙箱中运行，增强任务运行时的安全性。
 
-
-
 ## 在安全沙箱中运行 Secretflow 任务
 
-基于 Kuscia 框架， 你可以快速体验在安全沙箱中运行 Secretflow 任务，这里以部署中心化组网模式为例，关于更多的部署细节请参考[快速入门](../getting_started/quickstart_cn.html)。
+基于 Kuscia 框架， 你可以快速体验在安全沙箱中运行 Secretflow 任务，这里以部署中心化组网模式为例，关于更多的部署细节请参考[快速入门](../getting_started/quickstart_cn.md)。
 
 1. 配置 Kuscia 镜像，以下示例选择使用 latest 版本镜像：
 
@@ -20,13 +18,13 @@ export KUSCIA_IMAGE=secretflow/kuscia
 
 2. 获取 Kuscia 安装脚本，安装脚本会下载到当前目录：
 
-```bash 
+```bash
 docker run --rm -v $(pwd):/tmp/kuscia $KUSCIA_IMAGE cp -f /home/kuscia/scripts/deploy/start_standalone.sh /tmp/kuscia
 ```
 
 3. 开启特权配置，并以中心化组网模式启动集群（开启容器特权时，会带来容器逃逸的风险，建议使用安全容器 kata)：
 
-```bash 
+```bash
 # 开启特权配置，使得 Kuscia 可以通过特权方式启动 Secretflow 容器。
 export ALLOW_PRIVILEGED=true
 
@@ -36,7 +34,7 @@ export ALLOW_PRIVILEGED=true
 
 4. 执行作业：
 
-```bash 
+```bash
 # 登入 master 容器。
 docker exec -it ${USER}-kuscia-master bash
 
@@ -46,4 +44,3 @@ scripts/user/create_example_job.sh NSJAIL_PSI
 # 查看作业状态。
 kubectl get kj
 ```
-


### PR DESCRIPTION
- 修复所有引用内部文档的链接（从 .html 写法改为使用相对路径指向在文件系统上真实的 .md 文件）
- 显式地声明某些章节的 target（比如 `#peer-to-peer` ）来避免内容变化后链接失效