### PR TITLE
【OSCP】 modify Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,18 +45,18 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: ## Generate CustomResourceDefinition objects.
-	sh hack/generate-crds.sh
+	bash hack/generate-crds.sh
 
 .PHONY: generate
 generate: gen-clientset gen-proto-code  ## Generate all code that Kuscia needs.
 
 .PHONY: gen-clientset
 gen-clientset:  # Generate CRD runtime.Object and Clientset\Informer|Listers.
-	sh hack/update-codegen.sh
+	bash hack/update-codegen.sh
 
 .PHONY: gen-proto-code
 gen-proto-code:  # Generate protobuf golang code that Kuscia needs.
-	sh hack/proto-to-go.sh
+	bash hack/proto-to-go.sh
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.
@@ -90,7 +90,7 @@ clean: # clean build and test product.
 
 .PHONY: build
 build: fmt vet ## Build kuscia binary.
-	sh hack/build.sh
+	bash hack/build.sh
 
 .PHONY: docs
 docs: ## Build docs.


### PR DESCRIPTION
hack目录下的脚本都声明需要使用 Bash 来执行，而Makefile中使用
```
sh build.sh
```
的方式执行，在Ubuntu22.04下出现如下报错：
![07_23_1620.png](https://s2.loli.net/2023/07/23/LDmlxSnFpWehvNu.png)
修改后，经测试，文档的具体操作流程和脚本能够成功运行：
```bash
make build
```
![07_23_1510.png](https://s2.loli.net/2023/07/23/ayd4nBS7Q5FZjxk.png)
```bash
make image
```
![07_23_1509.png](https://s2.loli.net/2023/07/23/xN729WpogTIJGMa.png)
```bash
make docs
```
![07_23_1606.png](https://s2.loli.net/2023/07/23/YuVCOvBzf2Tk146.png)