### PR TITLE
fix: 使用GRPC的方式创建DomainData，LabelInitiator的指定错误

### DIFF
--- a/pkg/kusciaapi/service/domaindata_service.go
+++ b/pkg/kusciaapi/service/domaindata_service.go
@@ -95,7 +95,7 @@ func (s domainDataService) CreateDomainData(ctx context.Context, request *kuscia
 	Labels[LabelDomainDataType] = request.Type
 	Labels[LabelDomainDataVendor] = request.Vendor
 	Labels[common.LabelInterConnProtocolType] = "kuscia"
-	Labels[common.LabelInitiator] = request.DomaindataId
+	Labels[common.LabelInitiator] = request.DomainId
 	kusciaDomainData := &v1alpha1.DomainData{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   request.DomaindataId,


### PR DESCRIPTION

通过创建出来的DomainData的yaml可以看到是LabelInitiator的指定错误，修复后在本地测试可以成功
![2023-12-05 10 49 41](https://github.com/secretflow/kuscia/assets/20870282/05569840-fb4b-48c2-901b-35a19fca2535)

JAVA 侧的调用GRPC代码
```java
  Domaindata.CreateDomainDataResponse aliceDataResponse = kusciaDomainDataRpc.createDomainData(
                Domaindata.CreateDomainDataRequest.newBuilder()
                        .setDomaindataId("alice-table")
                        .setName("alice.csv")
                        .setType(DomainDataTypeEnum.TABLE.getCode())
                        .setRelativeUri("alice.csv")
                        .setDomainId("alice")
                        .setFileFormat(Common.FileFormat.CSV)
                        .addAllColumns(
                                Lists.newArrayList(
                                        Common.DataColumn.newBuilder()
                                                .setName("id1")
                                                .setType("int")
                                                .setComment("")
                                                .build()
                                )
                        )
                        .build()
        );
        System.out.println("alice create data response:" + aliceDataResponse.getData());
```