### PR TITLE
docs: enable experimental link check plugin

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,13 +29,13 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-import os.path
-
 # -- Project information -----------------------------------------------------
 
-project = 'Kuscia'
-copyright = '2023 Ant Group Co., Ltd.'
-author = 'Kuscia authors'
+from importlib.util import find_spec
+
+project = "Kuscia"
+copyright = "2023 Ant Group Co., Ltd."
+author = "Kuscia authors"
 
 # -- General configuration ---------------------------------------------------
 
@@ -43,36 +43,33 @@ author = 'Kuscia authors'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.napoleon',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.graphviz',
-    'sphinx.ext.todo',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.extlinks',
-    'sphinx.ext.autosectionlabel',
-    'myst_parser',
-    "nbsphinx",
-    'sphinxcontrib.actdiag',
-    'sphinxcontrib.blockdiag',
-    'sphinxcontrib.nwdiag',
-    'sphinxcontrib.packetdiag',
-    'sphinxcontrib.rackdiag',
-    'sphinxcontrib.seqdiag',
-    'sphinx_design',
+    "sphinx.ext.napoleon",
+    "sphinx.ext.graphviz",
+    "sphinx.ext.todo",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.extlinks",
+    "sphinx.ext.autosectionlabel",
+    "myst_parser",
+    "sphinx_design",
 ]
 
-nbsphinx_requirejs_path = ''
+# Link check extension
+if find_spec("sphinx_jsx"):
+    extensions.append("sphinx_jsx")
+
+
+nbsphinx_requirejs_path = ""
 
 # Make sure the target is unique
 autosectionlabel_prefix_document = True
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", ".venv"]
 
 # Enable TODO
 todo_include_todos = True
@@ -82,20 +79,20 @@ todo_include_todos = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'pydata_sphinx_theme'
+html_theme = "pydata_sphinx_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
-html_favicon = '_static/favicon.ico'
+html_favicon = "_static/favicon.ico"
 
 html_css_files = [
-    'css/custom.css',
+    "css/custom.css",
 ]
 
-html_js_files = ['js/custom.js']
+html_js_files = ["js/custom.js"]
 
 html_theme_options = {
     "icon_links": [
@@ -140,9 +137,9 @@ myst_heading_anchors = 6
 # app setup hook
 def setup(app):
     app.add_config_value(
-        'recommonmark_config',
+        "recommonmark_config",
         {
-            'auto_toc_tree_section': 'Contents',
+            "auto_toc_tree_section": "Contents",
         },
         True,
     )

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,14 +1,9 @@
-myst-parser==2.0.0
-rstcheck==6.1.2
-sphinx==6.2.1
-nbsphinx==0.9.2
-sphinx-autobuild==2021.3.14
-sphinx-markdown-parser==0.2.4
-sphinxcontrib-actdiag==3.0.0
-sphinxcontrib-blockdiag==3.0.0
-sphinxcontrib-nwdiag==2.0.0
-sphinxcontrib-seqdiag==3.0.0
-pytablewriter==0.64.2
-linkify-it-py==2.0.2
-sphinx_design==0.4.1
-pydata-sphinx-theme==0.13.3
+myst-parser~=2.0
+rstcheck~=6.0
+sphinx~=7.2
+sphinx-autobuild
+linkify-it-py~=2.0
+sphinx_design
+pydata-sphinx-theme~=0.15
+# link check extension
+secretflow-doctools==0.0.0


### PR DESCRIPTION
# 文档：试验性的链接检查工具

## 变更

- 关键依赖 `sphinx` `myst-parser` 升级到最新版本；
- **`sphinx~=7` 适用的最低 Python 版本是 3.9**，开发者敬请重新配置 Python 环境；
   - 重新 `pip install -r requirements.txt`
- 去除目前没有用到的冗余插件
- **新增依赖 `secretflow-doctools==0.0.0`，新增 Sphinx 插件 `sphinx_jsx`** （检查工具）
- 文档内容不受影响

## 使用

### 文档本地构建

**文档本地构建的方式及预览效果暂时没有变化**：

- `python -m sphinx -b html ./docs ./docs/_build/html` 或者
- `cd docs && make html`

### 链接检查

运行以下命令

```bash
cd docs
make jsx
```

检查流程和构建流程目前分开，即检查之后仍然要另外构建。

在之后，两个流程/命令会合并，命令和使用方式将会有进一步调整。

## 链接检查项目

当前实现以下 5 种规则，均针对**外部链接**（所有 `https?://` 链接）。

**错误码当前非稳定不变，未来随时可能会调整；** 以下均为示例，请以实际运行结果为准。

### Error `sphinx::linkcheck::not_found`

<img width="1283" alt="Screenshot 2024-04-12 at 3 06 25 PM" src="https://github.com/secretflow/kuscia/assets/93302820/244007ef-3bb8-461c-b692-e143bffa57d8">

对链接的 GET 请求返回 HTTP 400~499 时报告这一问题。

**注意：来源网站必须响应 HTTP 400~499；如果响应如 HTTP 200，但实际浏览器页面显示 “找不到内容”，插件当前暂时无法识别这一情况。**

### Error `sphinx::linkcheck::failed`

<img width="1349" alt="Screenshot 2024-04-12 at 3 09 05 PM" src="https://github.com/secretflow/kuscia/assets/93302820/5ddfc5da-20e0-449e-bdfe-286f2df33374">

对链接的 GET 请求返回网络错误，或者是 HTTP 500~599 ，报告这一问题；目前发现的常见情况是：

- 链接实际是代码示例（如上图），但是因为开启了 [`linkify`][linkify] 插件，类似链接的文本会被转换为链接（在页面上也的确会显示为链接）；建议行内代码示例 <code>\`使用代码格式`</code> 进行书写；或是关闭 linkify 插件
- 实际的网络问题

[linkify]: https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#linkify

### Warning `sphinx::linkcheck::special_address`

<img width="1424" alt="Screenshot 2024-04-12 at 3 14 37 PM" src="https://github.com/secretflow/kuscia/assets/93302820/45bf0c6d-68c5-4d5b-8232-4fdb64f7bc9b">

与上面 `sphinx::linkcheck::failed` 情况类似，`http://localhost` 等保留的示例链接会被识别成真正可点击的链接

### Warning `sphinx::linkcheck::not_permalink`

<img width="1421" alt="Screenshot 2024-04-12 at 3 17 32 PM" src="https://github.com/secretflow/kuscia/assets/93302820/6dd8ce82-b7c4-4bd6-a52c-e594dc0eae95">

链接指向如 GitHub 等 VCS 托管服务的文件，但未使用包含版本信息的永久链接时，报告这一问题；

VCS 目前仅支持 GitHub

**这个问题目前仅作扫描用，暂无解决方案，待后续增强**

### Info `sphinx::linkcheck::redirected`

<img width="1403" alt="Screenshot 2024-04-12 at 3 20 11 PM" src="https://github.com/secretflow/kuscia/assets/93302820/75faea54-6e32-401e-a61f-2d60a71d94e0">

链接被重定向（HTTP 301/308）时报告这一问题；代表链接被永久重定向，建议更新源码。
