### PR TITLE
remove duplicate bazel rule about domaindatasource_cc_proto

### DIFF
--- a/proto/api/v1alpha1/datamesh/BUILD.bazel
+++ b/proto/api/v1alpha1/datamesh/BUILD.bazel
@@ -49,7 +49,7 @@ proto_library(
 )
 
 cpp_proto_library(
-    name = "domaindatasource_cc_proto",
+    name = "domaindatasource_cpp_proto",
     protos = [
         ":domaindatasource_proto",
     ],


### PR DESCRIPTION
remove duplicate bazel rule about domaindatasource_cc_proto

change 'domaindatasource_cc_proto' to 'domaindatasource_cpp_proto'