### PR TITLE
fix: Fix pushd error/improper use in the script

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -76,3 +76,4 @@ elif [[ $app_type == "transport" ]]; then
   build_transport
 fi
 
+popd

--- a/hack/k3s/build.sh
+++ b/hack/k3s/build.sh
@@ -25,7 +25,7 @@ function build_k3s() {
     KINE_VERSION="github.com/k3s-io/kine@v0.11.3"
     pushd build/k3s
     go mod edit -replace github.com/k3s-io/kine="${KINE_VERSION}"
-    pushd
+    popd
   fi
 
   cp -rf hack/k3s/build-kuscia-k3s-binary.sh build/k3s/scripts

--- a/thirdparty/fate/hack/build.sh
+++ b/thirdparty/fate/hack/build.sh
@@ -30,3 +30,4 @@ pushd $base_dir
 
 build_kuscia
 
+popd


### PR DESCRIPTION
Fixed an issue in the script "hack/k3s/build.sh" where the pushd command lacked directory parameter, though it can work now. This is not the usual usage, it can easily cause confusion. To address this issue, I replaced the command with popd.
And for the other two files, I think there should be 'popd' after 'pushd'.