### PR TITLE
Bug fix #321: psi template, update curve_type to ecdh_curve

### DIFF
--- a/scripts/templates/task_input_config.2pc_balanced_psi.json
+++ b/scripts/templates/task_input_config.2pc_balanced_psi.json
@@ -28,7 +28,7 @@
     "domain": "data_prep",
     "name": "psi",
     "version": "0.0.4",
-    "attr_paths": ["input/receiver_input/key", "input/sender_input/key", "protocol", "precheck_input", "bucket_size", "curve_type", "left_side"],
+    "attr_paths": ["input/receiver_input/key", "input/sender_input/key", "protocol", "precheck_input", "bucket_size", "ecdh_curve", "left_side"],
     "attrs": [{
       "ss": ["id1"]
     }, {

--- a/scripts/templates/task_input_config.2pc_balanced_psi_dp.json
+++ b/scripts/templates/task_input_config.2pc_balanced_psi_dp.json
@@ -28,7 +28,7 @@
     "domain": "data_prep",
     "name": "psi",
     "version": "0.0.4",
-    "attr_paths": ["input/receiver_input/key", "input/sender_input/key", "protocol", "precheck_input", "bucket_size", "curve_type","left_side"],
+    "attr_paths": ["input/receiver_input/key", "input/sender_input/key", "protocol", "precheck_input", "bucket_size", "ecdh_curve","left_side"],
     "attrs": [{
       "ss": ["id1"]
     }, {


### PR DESCRIPTION
Hi  there, 

I noticed the latest psi, the attrs of `curve` has changed to ecdh_curve.  However, the template in the cuscia did not change accordingly.

https://github.com/secretflow/secretpad/blob/1467a1bdb6f38a31aa81cf93425a4ac1850b48e3/config/components/secretflow.json#L286