### PR TITLE
[OSCP]feat:add kuscia task Related observational indicators

### DIFF
--- a/cmd/kuscia/modules/ktexporter.go
+++ b/cmd/kuscia/modules/ktexporter.go
@@ -1,0 +1,56 @@
+// Copyright 2023 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modules
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	pkgcom "github.com/secretflow/kuscia/pkg/common"
+	"github.com/secretflow/kuscia/pkg/ktexporter"
+	"github.com/secretflow/kuscia/pkg/utils/readyz"
+)
+
+type ktExporterModule struct {
+	moduleRuntimeBase
+	runMode            pkgcom.RunModeType
+	domainID           string
+	rootDir            string
+	metricUpdatePeriod uint
+	ktExportPort       string
+}
+
+func NewKtExporter(i *ModuleRuntimeConfigs) (Module, error) {
+	readyURI := fmt.Sprintf("http://127.0.0.1:%s", i.KtExportPort)
+	return &ktExporterModule{
+		moduleRuntimeBase: moduleRuntimeBase{
+			name:         "ktexporter",
+			readyTimeout: 60 * time.Second,
+			rdz: readyz.NewHTTPReadyZ(readyURI, 404, func(body []byte) error {
+				return nil
+			}),
+		},
+		runMode:            i.RunMode,
+		domainID:           i.DomainID,
+		rootDir:            i.RootDir,
+		metricUpdatePeriod: i.MetricUpdatePeriod,
+		ktExportPort:       i.KtExportPort,
+	}, nil
+}
+
+func (exporter *ktExporterModule) Run(ctx context.Context) error {
+	return ktexporter.KtExporter(ctx, exporter.runMode, exporter.domainID, exporter.metricUpdatePeriod, exporter.ktExportPort)
+}

--- a/cmd/kuscia/modules/metricexporter.go
+++ b/cmd/kuscia/modules/metricexporter.go
@@ -51,6 +51,7 @@ func NewMetricExporter(i *ModuleRuntimeConfigs) (Module, error) {
 			"node-exporter": "http://localhost:" + i.NodeExportPort + "/metrics",
 			"envoy":         envoyexporter.GetEnvoyMetricURL(),
 			"ss":            "http://localhost:" + i.SsExportPort + "/ssmetrics",
+			"kt":            "http://localhost:" + i.KtExportPort + "/ktmetrics",
 		},
 	}, nil
 }

--- a/cmd/kuscia/modules/runtime.go
+++ b/cmd/kuscia/modules/runtime.go
@@ -51,6 +51,7 @@ type ModuleRuntimeConfigs struct {
 	TransportPort           int
 	InterConnSchedulerPort  int
 	SsExportPort            string
+	KtExportPort            string
 	NodeExportPort          string
 	MetricExportPort        string
 	KusciaKubeConfig        string
@@ -190,6 +191,7 @@ func NewModuleRuntimeConfigs(ctx context.Context, kusciaConf confloader.KusciaCo
 	}
 
 	// init exporter ports
+	dependencies.KtExportPort = "9093"
 	dependencies.SsExportPort = "9092"
 	dependencies.NodeExportPort = "9100"
 	dependencies.MetricExportPort = "9091"

--- a/cmd/kuscia/start/start.go
+++ b/cmd/kuscia/start/start.go
@@ -90,6 +90,7 @@ func Start(ctx context.Context, configFile string) error {
 	mm.Regist("metricexporter", modules.NewMetricExporter, autonomy, lite, master)
 	mm.Regist("nodeexporter", modules.NewNodeExporter, autonomy, lite, master)
 	mm.Regist("ssexporter", modules.NewSsExporter, autonomy, lite, master)
+	mm.Regist("ktexporter", modules.NewKtExporter, autonomy, lite, master)
 	mm.Regist("scheduler", modules.NewScheduler, autonomy, master)
 	mm.Regist("transport", modules.NewTransport, autonomy, lite)
 
@@ -104,7 +105,8 @@ func Start(ctx context.Context, configFile string) error {
 	mm.SetDependencies("kusciaapi", "k3s", "config", "domainroute")
 	mm.SetDependencies("scheduler", "k3s")
 	mm.SetDependencies("ssexporter", "envoy")
-	mm.SetDependencies("metricexporter", "envoy", "ssexporter", "nodeexporter")
+	mm.SetDependencies("ktexporter", "envoy")
+	mm.SetDependencies("metricexporter", "envoy", "ssexporter", "ktexporter", "nodeexporter")
 	mm.SetDependencies("transport", "envoy")
 
 	mm.AddReadyHook(func(ctx context.Context, mdls map[string]modules.Module) error {

--- a/go.mod
+++ b/go.mod
@@ -271,6 +271,7 @@ require (
 )
 
 replace (
+	github.com/secretflow/kuscia/pkg/ktexporter => ./pkg/ktexporter
 	k8s.io/api => k8s.io/api v0.26.11
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.26.11
 	k8s.io/apimachinery => k8s.io/apimachinery v0.26.11

--- a/pkg/ktexporter/ktexporter.go
+++ b/pkg/ktexporter/ktexporter.go
@@ -1,0 +1,88 @@
+// Copyright 2023 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ktexporter
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/secretflow/kuscia/pkg/ktexporter/ktmetrics"
+	"github.com/secretflow/kuscia/pkg/ktexporter/ktpromexporter"
+	"github.com/secretflow/kuscia/pkg/ktexporter/parse"
+
+	pkgcom "github.com/secretflow/kuscia/pkg/common"
+	"github.com/secretflow/kuscia/pkg/utils/nlog"
+)
+
+var (
+	ReadyChan = make(chan struct{})
+)
+
+func KtExporter(ctx context.Context, runMode pkgcom.RunModeType, domainID string, exportPeriod uint, port string) error {
+	// read the config
+	_, AggregationMetrics := parse.LoadMetricConfig()
+	clusterAddresses, _ := parse.GetClusterAddress(domainID)
+	localDomainName := domainID
+	var MetricTypes = ktpromexporter.NewMetricTypes_kt()
+
+	reg := ktpromexporter.ProduceRegister()
+	lastClusterMetricValues, err := ktmetrics.GetKtMetricResults(runMode, localDomainName, clusterAddresses, AggregationMetrics, exportPeriod)
+	if err != nil {
+		nlog.Warnf("Fail to get kt metric results, err: %v", err)
+		return err
+	}
+	// export the cluster metrics
+	ticker := time.NewTicker(time.Duration(exportPeriod) * time.Second)
+	defer ticker.Stop()
+	go func(runMode pkgcom.RunModeType, reg *prometheus.Registry, MetricTypes map[string]string, exportPeriods uint, lastClusterMetricValues map[string]float64) {
+		for range ticker.C {
+			// get clusterName and clusterAddress
+			clusterAddresses, _ = parse.GetClusterAddress(domainID)
+			// get cluster metrics
+			currentClusterMetricValues, err := ktmetrics.GetKtMetricResults(runMode, localDomainName, clusterAddresses, AggregationMetrics, exportPeriods)
+			if err != nil {
+				nlog.Warnf("Fail to get kt metric results, err: %v", err)
+			}
+
+			// calculate the change values of cluster metrics
+
+			ktpromexporter.UpdateMetrics(reg, currentClusterMetricValues, MetricTypes)
+		}
+	}(runMode, reg, MetricTypes, exportPeriod, lastClusterMetricValues)
+	// export to the prometheus
+	ktServer := http.NewServeMux()
+	ktServer.Handle("/ktmetrics", promhttp.HandlerFor(
+		reg,
+		promhttp.HandlerOpts{
+			EnableOpenMetrics: true,
+		}))
+	go func() {
+		if err := http.ListenAndServe("0.0.0.0:"+port, ktServer); err != nil {
+			nlog.Error("Fail to start the metric exporterserver", err)
+		}
+	}()
+	defer func() {
+		close(ReadyChan)
+		nlog.Info("Start to export metrics...")
+	}()
+
+	<-ctx.Done()
+	nlog.Info("Stopping the metric exporter...")
+	return nil
+}

--- a/pkg/ktexporter/ktmetrics/ktmetrics.go
+++ b/pkg/ktexporter/ktmetrics/ktmetrics.go
@@ -1,0 +1,632 @@
+package ktmetrics
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"os"
+
+	"github.com/secretflow/kuscia/pkg/ktexporter/parse"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/secretflow/kuscia/pkg/utils/nlog"
+
+	pkgcom "github.com/secretflow/kuscia/pkg/common"
+)
+
+// ContainerConfig represents the config.json structure.
+type ContainerConfig struct {
+	Hostname string `json:"hostname"`
+}
+
+type NetStats struct {
+	RecvBytes uint64  // Bytes
+	XmitBytes uint64  // Bytes
+	RecvBW    float64 // bps
+	XmitBW    float64 // bps
+}
+
+type KusicaTaskStats struct {
+	CtrStats ContainerStats
+	NetIO    NetStats
+}
+
+func GetKusciaTaskPID() (map[string]string, error) {
+	const containerdDir = "/home/kuscia/containerd/run/io.containerd.runtime.v2.task/k8s.io/"
+	taskIDToPID := make(map[string]string)
+	containerFiles, err := ioutil.ReadDir(containerdDir)
+	if err != nil {
+		nlog.Info("Error reading directory:", err)
+		return taskIDToPID, err
+	}
+	for _, containerFile := range containerFiles {
+		if !containerFile.IsDir() {
+			continue
+		}
+		containerDir := filepath.Join(containerdDir, containerFile.Name())
+		// Read init.pid
+		pidFile := filepath.Join(containerDir, "init.pid")
+		pidData, err := ioutil.ReadFile(pidFile)
+		if err != nil {
+			nlog.Info("Error reading pid containerFile:", err)
+			return taskIDToPID, err
+		}
+
+		// Read config.json
+		configFile := filepath.Join(containerDir, "config.json")
+		configData, err := ioutil.ReadFile(configFile)
+		if err != nil {
+			nlog.Info("Error reading config containerFile:", err)
+			return taskIDToPID, err
+		}
+
+		var config ContainerConfig
+		err = jsoniter.Unmarshal(configData, &config)
+		if err != nil {
+			nlog.Info("Error parsing config containerFile:", err)
+			return taskIDToPID, err
+		}
+		if config.Hostname != "" {
+			taskIDToPID[config.Hostname] = string(pidData)
+		}
+	}
+
+	return taskIDToPID, nil
+}
+
+// GetContainerMappings fetches the container info using crictl ps command
+func GetTaskIDToContainerID() (map[string]string, error) {
+	cmd := exec.Command("crictl", "ps")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println("failed to execute crictl ps.", err)
+		return nil, err
+	}
+
+	lines := strings.Split(out.String(), "\n")
+
+	if len(lines) < 2 {
+		fmt.Println("unexpected output format from crictl ps", err)
+		return nil, err
+	}
+
+	taskIDToContainerID := make(map[string]string)
+	for _, line := range lines[1:] {
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 8 {
+			fmt.Printf("unexpected output format for line: %s", line)
+			return nil, err
+		}
+		state := fields[5] // 通常，crictl ps 的第四个字段为状态(State)
+		if state != "Running" {
+			nlog.Infof("state is %s", state)
+			continue
+		}
+		containerID := fields[0]
+		kusciaTaskID := fields[len(fields)-1]
+		taskIDToContainerID[kusciaTaskID] = containerID
+	}
+
+	return taskIDToContainerID, nil
+}
+
+// ContainerStats holds the stats information for a container
+type ContainerStats struct {
+	CPUPercentage string
+	Memory        string
+	Disk          string
+	Inodes        string
+}
+
+// GetContainerStats fetches the container stats using crictl stats command
+func GetContainerStats() (map[string]ContainerStats, error) {
+	// Execute the crictl stats command
+	cmd := exec.Command("crictl", "stats")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println("failed to execute crictl stats", err)
+		//nlog.Warn("failed to execute crictl stats", err)
+		return nil, err
+	}
+
+	// Parse the output
+	lines := strings.Split(out.String(), "\n")
+	if len(lines) < 2 {
+		fmt.Println("unexpected output format from crictl stats")
+		//nlog.Warn("unexpected output format from crictl stats")
+		return nil, err
+	}
+
+	// Create a map to hold the stats for each container
+	statsMap := make(map[string]ContainerStats)
+
+	// Skip the header line and iterate over the output lines
+	for _, line := range lines[1:] {
+		// Skip empty lines
+		if line == "" {
+			continue
+		}
+
+		// Split the line by whitespace
+		fields := strings.Fields(line)
+		if len(fields) < 5 {
+			fmt.Printf("unexpected output format for line: %s", line)
+			//nlog.Warn("unexpected output format for line: %s", line)
+			return nil, err
+		}
+
+		// Extract the stats information
+		containerID := fields[0]
+		stats := ContainerStats{
+			CPUPercentage: fields[1],
+			Memory:        fields[2],
+			Disk:          fields[3],
+			Inodes:        fields[4],
+		}
+		// Add the stats to the map
+		statsMap[containerID] = stats
+	}
+
+	return statsMap, nil
+}
+
+// GetMemoryUsageStats retrieves memory usage statistics (virtual, physical, swap) for a given container
+func GetMaxMemoryUsageStats(pid string, cidPrefix string) (uint64, uint64, error) {
+	// Find the full CID based on the prefix
+	cid, err := findCIDByPrefix(cidPrefix)
+	if err != nil {
+		nlog.Warn("failed to find full CID by prefix", err)
+		return 0, 0, err
+	}
+
+	// Get Virtual Memory (VmPeak)
+	virtualMemory, err := getVirtualMemoryUsage(pid)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// Get Physical and Swap Memory (max usage in bytes)
+	physicalMemory, err := getPhysicalMemoryUsage(cid)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return virtualMemory, physicalMemory, nil
+}
+
+// getVirtualMemoryUsage retrieves the peak virtual memory usage for a given PID
+func getVirtualMemoryUsage(pid string) (uint64, error) {
+	// Read /proc/[pid]/status
+	statusFile := filepath.Join("/proc", pid, "status")
+	statusData, err := ioutil.ReadFile(statusFile)
+	if err != nil {
+		nlog.Warn("failed to read /proc/[pid]/status", err)
+		return 0, err
+	}
+
+	// Parse VmPeak from status
+	lines := strings.Split(string(statusData), "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "VmPeak:") {
+			parts := strings.Fields(line)
+			if len(parts) == 3 {
+				vmPeak, err := strconv.ParseUint(parts[1], 10, 64)
+				if err != nil {
+					nlog.Warn("failed to parse VmPeak value", err)
+					return 0, err
+				}
+				return vmPeak * 1024, nil // Convert to bytes
+			}
+		}
+	}
+
+	nlog.Warn("VmPeak not found in /proc/[pid]/status")
+	return 0, fmt.Errorf("VmPeak not found in /proc/[pid]/status")
+}
+
+// getPhysicalMemoryUsage retrieves the peak physical memory usage for a cgroup
+func getPhysicalMemoryUsage(cid string) (uint64, error) {
+	// Read /sys/fs/cgroup/memory/k8s.io/[cid]/memory.max_usage_in_bytes
+	memMaxUsageFile := filepath.Join("/sys/fs/cgroup/memory/k8s.io", cid, "memory.max_usage_in_bytes")
+	memMaxUsageData, err := ioutil.ReadFile(memMaxUsageFile)
+	if err != nil {
+		nlog.Warn("failed to read memory.max_usage_in_bytes", err)
+		return 0, err
+	}
+
+	// Parse the max usage in bytes
+	physicalMemory, err := strconv.ParseUint(strings.TrimSpace(string(memMaxUsageData)), 10, 64)
+	if err != nil {
+		nlog.Warn("failed to parse memory.max_usage_in_bytes", err)
+		return 0, err
+	}
+
+	return physicalMemory, nil
+}
+
+// GetIOStats retrieves I/O statistics (read_bytes, write_bytes) for a given PID
+func GetTotalIOStats(pid string) (uint64, uint64, error) {
+	// Read /proc/[pid]/io
+	ioFile := filepath.Join("/proc", pid, "io")
+	ioData, err := ioutil.ReadFile(ioFile)
+	if err != nil {
+		nlog.Warn("failed to read /proc/[pid]/io", err)
+		return 0, 0, err
+	}
+
+	var readBytes, writeBytes uint64
+
+	// Parse the file contents to find read_bytes and write_bytes
+	lines := strings.Split(string(ioData), "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "read_bytes:") {
+			parts := strings.Fields(line)
+			readBytes, err = strconv.ParseUint(parts[1], 10, 64)
+			if err != nil {
+				nlog.Warn("failed to parse read_bytes", err)
+				return 0, 0, err
+			}
+		}
+		if strings.HasPrefix(line, "write_bytes:") {
+			parts := strings.Fields(line)
+			writeBytes, err = strconv.ParseUint(parts[1], 10, 64)
+			if err != nil {
+				nlog.Warn("failed to parse write_bytes", err)
+				return 0, 0, err
+			}
+		}
+	}
+
+	return readBytes, writeBytes, nil
+}
+
+func GetContainerNetIOFromProc(defaultIface, pid string) (recvBytes, xmitBytes uint64, err error) {
+	netDevPath := fmt.Sprintf("/proc/%s/net/dev", pid)
+	data, err := ioutil.ReadFile(netDevPath)
+	if err != nil {
+		//nlog.Warn("Fail to read the path", netDevPath)
+		return recvBytes, xmitBytes, err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	if len(lines) < 3 {
+		//nlog.Error("unexpected format in ", netDevPath)
+		fmt.Println("unexpected format in ", netDevPath)
+		return recvBytes, xmitBytes, err
+	}
+	recvByteStr := ""
+	xmitByteStr := ""
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 10 {
+			continue
+		}
+
+		iface := strings.Trim(fields[0], ":")
+		if iface == defaultIface {
+			recvByteStr = fields[1]
+			xmitByteStr = fields[9]
+		}
+	}
+	if recvByteStr == "" {
+		recvByteStr = "0"
+	}
+	if xmitByteStr == "" {
+		xmitByteStr = "0"
+	}
+	recvBytes, err = strconv.ParseUint(recvByteStr, 10, 64)
+	if err != nil {
+		//nlog.Error("Error converting string to uint64:", err)
+		fmt.Println("Error converting string to uint64:", err)
+		return recvBytes, xmitBytes, err
+	}
+	xmitBytes, err = strconv.ParseUint(xmitByteStr, 10, 64)
+	if err != nil {
+		//nlog.Error("Error converting string to uint64:", err)
+		fmt.Println("Error converting string to uint64:", err)
+		return recvBytes, xmitBytes, err
+	}
+
+	return recvBytes, xmitBytes, nil
+}
+
+func GetContainerBandwidth(curRecvBytes, preRecvBytes, curXmitBytes, preXmitBytes uint64, timeWindow float64) (recvBandwidth, xmitBandwidth float64, err error) {
+	recvBytesDiff := float64(curRecvBytes) - float64(preRecvBytes)
+	xmitBytesDiff := float64(curXmitBytes) - float64(preXmitBytes)
+
+	recvBandwidth = (recvBytesDiff * 8) / timeWindow
+	xmitBandwidth = (xmitBytesDiff * 8) / timeWindow
+
+	return recvBandwidth, xmitBandwidth, nil
+}
+
+// AggregateStatistics aggregate statistics using an aggregation function
+func AggregateStatistics(localDomainName string, clusterResults map[string]float64, networkResults []map[string]string, aggregationMetrics map[string]string, dstDomain string, MonitorPeriods uint) (map[string]float64, error) {
+	if len(networkResults) == 0 {
+		return clusterResults, nil
+	}
+	for _, taskid := range networkResults {
+		for metric, aggFunc := range aggregationMetrics {
+			metricID := localDomainName + ";" + dstDomain + ";" + metric + ";" + aggFunc + ";" + taskid["taskid"]
+			nlog.Infof("Generated metricID: %s", metricID)
+			nlog.Infof("Generated metricID: %s", metric)
+			nlog.Infof("Generated metricID: %s", aggFunc)
+			if metric != parse.KtLocalAddr && metric != parse.KtPeerAddr {
+				var err error
+				if aggFunc == parse.AggSum {
+					clusterResults[metricID], err = Sum(networkResults, metric)
+				} else if aggFunc == parse.AggAvg {
+					clusterResults[metricID], err = Avg(networkResults, metric)
+				} else if aggFunc == parse.AggMax {
+					clusterResults[metricID], err = Max(networkResults, metric)
+				} else if aggFunc == parse.AggMin {
+					clusterResults[metricID], err = Min(networkResults, metric)
+				}
+				if err != nil {
+					nlog.Warnf("Fail to get clusterResults from aggregation functions, err: %v", err)
+					return clusterResults, err
+				}
+				if metric == parse.MetricByteSent || metric == parse.MetricBytesReceived {
+					clusterResults[metricID] = Rate(clusterResults[metricID], float64(MonitorPeriods))
+				}
+			}
+		}
+	}
+	return clusterResults, nil
+}
+
+// Sum an aggregation function to sum up two network metrics
+func Sum(metrics []map[string]string, key string) (float64, error) {
+	sum := 0.0
+	for _, metric := range metrics {
+		val, err := strconv.ParseFloat(metric[key], 64)
+		if err != nil {
+			nlog.Warnf("fail to parse float: %s, key: %s, value: %f", metric[key], key, val)
+			return sum, err
+		}
+		sum += val
+	}
+	return sum, nil
+}
+
+// Avg an aggregation function to calculate the average of two network metrics
+func Avg(metrics []map[string]string, key string) (float64, error) {
+	sum, err := Sum(metrics, key)
+	if err != nil {
+		nlog.Warnf("Fail to get the sum of kt metrics, err: %v", err)
+		return sum, err
+	}
+	return sum / float64(len(metrics)), nil
+}
+
+// Max an aggregation function to calculate the maximum of two network metrics
+func Max(metrics []map[string]string, key string) (float64, error) {
+	max := math.MaxFloat64 * (-1)
+	for _, metric := range metrics {
+		val, err := strconv.ParseFloat(metric[key], 64)
+		if err != nil {
+			nlog.Warn("fail to parse float")
+			return max, err
+		}
+		if val > max {
+			max = val
+		}
+	}
+	return max, nil
+}
+
+// Min an aggregation function to calculate the minimum of two network metrics
+func Min(metrics []map[string]string, key string) (float64, error) {
+	min := math.MaxFloat64
+	for _, metric := range metrics {
+		val, err := strconv.ParseFloat(metric[key], 64)
+		if err != nil {
+			nlog.Warn("fail to parse float")
+			return min, err
+		}
+		if val < min {
+			min = val
+		}
+	}
+	return min, nil
+}
+
+// Rate an aggregation function to calculate the rate of a network metric between to metrics
+func Rate(metric1 float64, metric2 float64) float64 {
+	if metric2 == 0.0 {
+		return 0
+	}
+	return metric1 / metric2
+}
+
+// Alert an alert function that reports whether a metric value exceeds a given threshold
+func Alert(metric float64, threshold float64) bool {
+	return metric > threshold
+}
+
+// GetKtMetricResults Get the results of kt statistics after filtering
+func GetKtMetricResults(runMode pkgcom.RunModeType, localDomainName string, clusterAddresses map[string][]string, AggregationMetrics map[string]string, MonitorPeriods uint) (map[string]float64, error) {
+	// Initialize the result map
+	ktResults := make(map[string]float64)
+
+	// Iterate over each endpoint address from clusterAddresses (without using IP)
+	for _, endpointAddresses := range clusterAddresses {
+		for _, endpointAddress := range endpointAddresses {
+			// Log some information
+			nlog.Info("Processing endpoint address: ", endpointAddress)
+			ktMetrics, err := GetStatisticFromKt()
+			if err != nil {
+				nlog.Warnf("Fail to get statistics from kt, err: %v", err)
+				return ktResults, err
+			}
+			// Get the connection name (e.g., domain or IP)
+			endpointName := strings.Split(endpointAddress, ":")[0]
+
+			// Collect all ktMetrics into networkResults (no filtering)
+			var networkResults []map[string]string
+			networkResults = append(networkResults, ktMetrics...) // Add all ktMetrics data
+
+			// Perform aggregation based on metrics and store results in ktResults
+			ktResults, err = AggregateStatistics(localDomainName, ktResults, networkResults, AggregationMetrics, endpointName, MonitorPeriods)
+			if err != nil {
+				nlog.Warnf("Failed to aggregate statistics for endpoint %s: %v", endpointName, err)
+			}
+
+		}
+	}
+	// Return the aggregated ktResults
+	return ktResults, nil
+}
+
+func GetMetricChange(lastMetricValues map[string]float64, currentMetricValues map[string]float64) (map[string]float64, map[string]float64) {
+	for metric, value := range currentMetricValues {
+		nlog.Info("3333366666")
+		currentMetricValues[metric] = currentMetricValues[metric] - lastMetricValues[metric]
+		if currentMetricValues[metric] < 0 {
+			currentMetricValues[metric] = 0
+		}
+		lastMetricValues[metric] = value
+
+	}
+	return lastMetricValues, currentMetricValues
+}
+
+func findCIDByPrefix(prefix string) (string, error) {
+	cgroupDir := "/sys/fs/cgroup/cpu/k8s.io/"
+	files, err := ioutil.ReadDir(cgroupDir)
+	if err != nil {
+		return "", err
+	}
+
+	for _, file := range files {
+		if strings.HasPrefix(file.Name(), prefix) {
+			return file.Name(), nil
+		}
+	}
+
+	return "", os.ErrNotExist
+}
+
+func GetTotalCPUUsageStats(cidPrefix string) (uint64, error) {
+	//var stats CPUUsageStats
+
+	// Find the full CID based on the prefix
+	cid, err := findCIDByPrefix(cidPrefix)
+	if err != nil {
+		nlog.Warn("failed to find full CID by prefix", err)
+		return 0, err
+	}
+
+	// Read /sys/fs/cgroup/cpu/k8s.io/[cid]/cpuacct.usage
+	cgroupUsageFile := filepath.Join("/sys/fs/cgroup/cpu/k8s.io", cid, "cpuacct.usage")
+	cgroupUsageData, err := ioutil.ReadFile(cgroupUsageFile)
+	if err != nil {
+		nlog.Warn("failed to read cpuacct.usage", err)
+		return 0, err
+	}
+
+	// Parse cpuacct.usage
+	cpuUsage, err := strconv.ParseUint(strings.TrimSpace(string(cgroupUsageData)), 10, 64)
+	if err != nil {
+		nlog.Warn("failed to parse cpuacct.usage", err)
+		return 0, err
+	}
+
+	return cpuUsage, nil
+}
+
+func GetStatisticFromKt() ([]map[string]string, error) {
+	var preRecvBytes, preXmitBytes uint64
+	var tcpStatisticList []map[string]string
+	timeWindow := 1.0
+	taskToPID, err := GetKusciaTaskPID()
+	if err != nil {
+		nlog.Error("Fail to get container PIDs", err)
+	}
+
+	taskIDToContainerID, err := GetTaskIDToContainerID()
+	if err != nil {
+		nlog.Error("Fail to get container ID", err)
+	}
+
+	for kusciaTaskID, containerPID := range taskToPID {
+		containerID, exists := taskIDToContainerID[kusciaTaskID]
+		if !exists || containerID == "" {
+			// Skip this task if no valid CID is found
+			continue
+		}
+
+		recvBytes, xmitBytes, err := GetContainerNetIOFromProc("eth0", containerPID)
+		if err != nil {
+			nlog.Warn("Fail to get container network IO from proc")
+			continue
+		}
+
+		recvBW, xmitBW, err := GetContainerBandwidth(recvBytes, preRecvBytes, xmitBytes, preXmitBytes, timeWindow)
+		if err != nil {
+			nlog.Warn("Fail to get the network bandwidth of containers")
+			continue
+		}
+		preRecvBytes = recvBytes
+		preXmitBytes = xmitBytes
+		ktMetrics := make(map[string]string)
+		ktMetrics[parse.MetricRecvBytes] = fmt.Sprintf("%d", recvBytes)
+		ktMetrics[parse.MetricXmitBytes] = fmt.Sprintf("%d", xmitBytes)
+		ktMetrics[parse.MetricRecvBw] = fmt.Sprintf("%.2f", recvBW)
+		ktMetrics[parse.MetricXmitBw] = fmt.Sprintf("%.2f", xmitBW)
+		ktMetrics["taskid"] = kusciaTaskID
+		containerStats, err := GetContainerStats()
+		if err != nil {
+			nlog.Warn("Fail to get the stats of containers")
+			continue
+		}
+		ktMetrics[parse.MetricCPUPer] = containerStats[containerID].CPUPercentage
+		ktMetrics[parse.MetricDisk] = containerStats[containerID].Disk
+		ktMetrics[parse.MetricInodes] = containerStats[containerID].Inodes
+		ktMetrics[parse.MetricMemory] = containerStats[containerID].Memory
+
+		cpuUsage, err := GetTotalCPUUsageStats(containerID)
+		if err != nil {
+			nlog.Warn("Fail to get the total CPU usage stats")
+			continue
+		}
+		ktMetrics[parse.MetricCPUUs] = fmt.Sprintf("%d", cpuUsage)
+
+		virtualMemory, physicalMemory, err := GetMaxMemoryUsageStats(containerPID, containerID)
+		if err != nil {
+			nlog.Warn("Fail to get the total memory stats")
+			continue
+		}
+		ktMetrics[parse.MetricVtMemory] = fmt.Sprintf("%d", virtualMemory)
+		ktMetrics[parse.MetricPsMemory] = fmt.Sprintf("%d", physicalMemory)
+
+		readBytes, writeBytes, err := GetTotalIOStats(containerPID)
+		if err != nil {
+			nlog.Warn("Fail to get the total IO stats")
+			continue
+		}
+		ktMetrics[parse.MetricReadBytes] = fmt.Sprintf("%d", readBytes)
+		ktMetrics[parse.MetricWriteBytes] = fmt.Sprintf("%d", writeBytes)
+
+		tcpStatisticList = append(tcpStatisticList, ktMetrics)
+	}
+
+	return tcpStatisticList, nil
+}

--- a/pkg/ktexporter/ktpromexporter/export.go
+++ b/pkg/ktexporter/ktpromexporter/export.go
@@ -1,0 +1,148 @@
+// Copyright 2023 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package metric the function to export metrics to Prometheus
+package ktpromexporter
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+
+	"github.com/secretflow/kuscia/pkg/utils/nlog"
+)
+
+func produceCounter(namespace string, name string, help string, labels map[string]string) prometheus.Counter {
+	return prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace:   namespace,
+			Name:        name,
+			Help:        help,
+			ConstLabels: labels,
+		})
+}
+
+func produceGauge(namespace string, name string, help string, labels map[string]string) prometheus.Gauge {
+	return prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Name:        name,
+			Help:        help,
+			ConstLabels: labels,
+		})
+}
+
+func produceHistogram(namespace string, name string, help string, labels map[string]string) prometheus.Histogram {
+	return prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace:   namespace,
+			Name:        name,
+			Help:        help,
+			ConstLabels: labels,
+		})
+}
+func produceSummary(namespace string, name string, help string, labels map[string]string) prometheus.Summary {
+	return prometheus.NewSummary(
+		prometheus.SummaryOpts{
+			Namespace:   namespace,
+			Name:        name,
+			Help:        help,
+			ConstLabels: labels,
+		})
+}
+
+var counters = make(map[string]prometheus.Counter)
+var gauges = make(map[string]prometheus.Gauge)
+var histograms = make(map[string]prometheus.Histogram)
+var summaries = make(map[string]prometheus.Summary)
+
+func produceMetric(reg *prometheus.Registry,
+	metricID string, metricType string) *prometheus.Registry {
+	splitedMetric := strings.Split(metricID, ";")
+	labels := make(map[string]string)
+	labels["type"] = "kt"
+	labels["remote_domain"] = splitedMetric[len(splitedMetric)-4]
+	name := splitedMetric[len(splitedMetric)-3]
+	labels["aggregation_function"] = splitedMetric[len(splitedMetric)-2]
+	labels["taskid"] = splitedMetric[len(splitedMetric)-1]
+	help := name + " aggregated by " + labels["aggregation_function"] + " from kt"
+	nameSpace := "kt"
+	if metricType == "Counter" {
+		counters[metricID] = produceCounter(nameSpace, name, help, labels)
+		reg.MustRegister(counters[metricID])
+	} else if metricType == "Gauge" {
+		gauges[metricID] = produceGauge(nameSpace, name, help, labels)
+		reg.MustRegister(gauges[metricID])
+	} else if metricType == "Histogram" {
+		histograms[metricID] = produceHistogram(nameSpace, name, help, labels)
+		reg.MustRegister(histograms[metricID])
+	} else if metricType == "Summary" {
+		summaries[metricID] = produceSummary(nameSpace, name, help, labels)
+		reg.MustRegister(summaries[metricID])
+	}
+	return reg
+}
+func formalize(metric string) string {
+	metric = strings.Replace(metric, "-", "_", -1)
+	metric = strings.Replace(metric, ".", "__", -1)
+	metric = strings.ToLower(metric)
+	return metric
+}
+func ProduceRegister() *prometheus.Registry {
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+	)
+	return reg
+}
+
+func UpdateMetrics(reg *prometheus.Registry,
+	clusterResults map[string]float64, MetricTypes map[string]string) {
+	nlog.Info("333335555")
+	for metric, val := range clusterResults {
+		nlog.Info("333334444")
+		metricID := formalize(metric)
+		splitedMetric := strings.Split(metric, ";")
+		var metricTypeID string
+		metricTypeID = splitedMetric[len(splitedMetric)-3]
+		metricType, ok := MetricTypes[metricTypeID]
+		if !ok {
+			nlog.Error("Fail to get metric types", ok)
+		}
+		switch metricType {
+		case "Counter":
+			if _, ok := counters[metricID]; !ok {
+				produceMetric(reg, metricID, metricType)
+			}
+			counters[metricID].Add(val)
+		case "Gauge":
+			if _, ok := gauges[metricID]; !ok {
+				produceMetric(reg, metricID, metricType)
+			}
+			gauges[metricID].Set(val)
+		case "Histogram":
+			if _, ok := histograms[metricID]; !ok {
+				produceMetric(reg, metricID, metricType)
+			}
+			histograms[metricID].Observe(val)
+		case "Summary":
+			if _, ok := summaries[metricID]; !ok {
+				produceMetric(reg, metricID, metricType)
+			}
+			summaries[metricID].Observe(val)
+		}
+	}
+}

--- a/pkg/ktexporter/ktpromexporter/type.go
+++ b/pkg/ktexporter/ktpromexporter/type.go
@@ -1,0 +1,41 @@
+// Copyright 2023 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package metric defines the type of metrics exporting to Prometheus
+package ktpromexporter
+
+const (
+	metricCounter = "Counter"
+	metricGauge   = "Gauge"
+)
+
+// NewMetricTypes_kt parse the metric types from a yaml file
+
+func NewMetricTypes_kt() map[string]string {
+	MetricTypes := make(map[string]string)
+	MetricTypes["recvbw"] = metricGauge
+	MetricTypes["xmitbw"] = metricGauge
+	MetricTypes["recvbytes"] = metricGauge
+	MetricTypes["xmitbytes"] = metricGauge
+	MetricTypes["cpu_percentage"] = metricGauge
+	MetricTypes["virtual_memory"] = metricGauge
+	MetricTypes["physical_memory"] = metricGauge
+	MetricTypes["readbytes"] = metricGauge
+	MetricTypes["writebytes"] = metricGauge
+	MetricTypes["cpu_usage"] = metricGauge
+	MetricTypes["memory"] = metricGauge
+	MetricTypes["disk"] = metricGauge
+	MetricTypes["inodes"] = metricGauge
+	return MetricTypes
+}

--- a/pkg/ktexporter/parse/config.go
+++ b/pkg/ktexporter/parse/config.go
@@ -1,0 +1,74 @@
+// Copyright 2023 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package parse configures files and domain files
+package parse
+
+// Config define the structure of the configuration file
+type MonitorConfig struct {
+	KtMetrics  []string
+	AggMetrics []string
+}
+
+const (
+	MetricRecvBytes     = "recvbytes"
+	MetricXmitBytes     = "xmitbytes"
+	MetricRecvBw        = "recvbw"
+	MetricXmitBw        = "xmitbw"
+	MetricCPUPer        = "cpu_percentage"
+	MetricCPUUs         = "cpu_usage"
+	MetricVtMemory      = "virtual_memory"
+	MetricPsMemory      = "physical_memory"
+	MetricMemory        = "memory"
+	MetricDisk          = "disk"
+	MetricInodes        = "inodes"
+	MetricByteSent      = "bytes_sent"
+	MetricBytesReceived = "bytes_received"
+	KtLocalAddr         = "localAddr"
+	KtPeerAddr          = "peerAddr"
+	MetricReadBytes     = "readbytes"
+	MetricWriteBytes    = "writebytes"
+
+	AggSum   = "sum"
+	AggAvg   = "avg"
+	AggMax   = "max"
+	AggMin   = "min"
+	AggAlert = "alert"
+	AggRate  = "rate"
+)
+
+// ReadConfig read the configuration and return each entry
+func LoadMetricConfig() ([]string, map[string]string) {
+	var config MonitorConfig
+	config.KtMetrics = append(config.KtMetrics,
+		MetricRecvBytes,
+		MetricXmitBytes,
+		MetricRecvBw,
+		MetricXmitBw,
+		MetricCPUPer,
+		MetricCPUUs,
+		MetricMemory,
+		MetricDisk,
+		MetricInodes,
+		MetricVtMemory,
+		MetricPsMemory,
+		MetricReadBytes,
+		MetricWriteBytes)
+	aggMetrics := make(map[string]string)
+	config.AggMetrics = append(config.AggMetrics, AggSum, AggSum, AggSum, AggSum, AggAvg, AggAvg, AggAvg, AggSum, AggSum, AggSum, AggSum, AggSum, AggSum)
+	for i, metric := range config.KtMetrics {
+		aggMetrics[metric] = config.AggMetrics[i]
+	}
+	return config.KtMetrics, aggMetrics
+}

--- a/pkg/ktexporter/parse/config_test.go
+++ b/pkg/ktexporter/parse/config_test.go
@@ -1,0 +1,53 @@
+// Copyright 2023 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadMetricConfig test LoadMetricConfig
+func TestLoadMetricConfig(t *testing.T) {
+	testCases := []struct {
+		name            string
+		expectedMetrics []string
+		expectedAgg     map[string]string
+	}{
+		{
+			name:            "Check LoadMetricConfig output",
+			expectedMetrics: []string{"recvbytes", "xmitbytes", "recvbw", "xmitbw", "cpu", "memory", "disk", "inodes"},
+			expectedAgg: map[string]string{
+				"recvbytes": "sum",
+				"xmitbytes": "sum",
+				"recvbw":    "sum",
+				"xmitbw":    "sum",
+				"cpu":       "avg",
+				"memory":    "avg",
+				"disk":      "sum",
+				"inodes":    "sum",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			metrics, agg := LoadMetricConfig()
+			require.Equal(t, tc.expectedMetrics, metrics, "Metrics do not match expected values")
+			require.Equal(t, tc.expectedAgg, agg, "Aggregated metrics do not match expected values")
+		})
+	}
+}

--- a/pkg/ktexporter/parse/domain.go
+++ b/pkg/ktexporter/parse/domain.go
@@ -1,0 +1,108 @@
+// Copyright 2023 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package parse configures files and domain files
+package parse
+
+import (
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strings"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/secretflow/kuscia/pkg/utils/nlog"
+)
+
+// GetIPFromDomain get a list of IP addresses from a local domain name
+func GetIPFromDomain(domainName string) (ipList []string) {
+	if IsIP(domainName) {
+		ipList = append(ipList, domainName)
+		return
+	}
+	ipAddresses, err := net.LookupIP(domainName)
+	if err != nil {
+		nlog.Warnf("Cannot find IP address: %s", err.Error())
+		return
+	}
+	for _, ip := range ipAddresses {
+		ipList = append(ipList, ip.String())
+	}
+	return
+}
+
+func IsIP(ipStr string) bool {
+	ip := net.ParseIP(ipStr)
+	return ip != nil
+}
+
+// GetClusterAddress get the address and port of a remote domain connected by a local domain
+func GetClusterAddress(domainID string) (map[string][]string, error) {
+	endpointAddresses := make(map[string][]string)
+	// get the results of config_dump
+	resp, err := http.Get("http://localhost:10000/config_dump?resource=dynamic_active_clusters")
+	if err != nil {
+		nlog.Error("Fail to get the results of config_dump", err)
+		return endpointAddresses, err
+	}
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+		}
+	}(resp.Body)
+	// parse the results of config_dump
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		nlog.Error("Fail to parse the results of config_dump", err)
+		return endpointAddresses, err
+	}
+	res := make(map[string]interface{})
+	err = jsoniter.Unmarshal(body, &res)
+	configs := jsoniter.Get(body, "configs")
+
+	for i := 0; ; i++ {
+		x := configs.Get(i)
+		if x.Size() == 0 {
+			break
+		}
+		loadAssignment := x.Get("cluster", "load_assignment")
+		clusterName := loadAssignment.Get("cluster_name").ToString()
+
+		if !strings.HasPrefix(clusterName, domainID+"-to-") {
+			break
+		}
+		endpoints := loadAssignment.Get("endpoints")
+
+		for j := 0; ; j++ {
+			lbEndpoints := endpoints.Get(j, "lb_endpoints")
+			if lbEndpoints.Size() == 0 {
+				break
+			}
+			for k := 0; ; k++ {
+				endpoint := lbEndpoints.Get(k)
+				if endpoint.Size() == 0 {
+					break
+				}
+				socketAddress := endpoint.Get("endpoint", "address", "socket_address")
+				address := socketAddress.Get("address")
+				portValue := socketAddress.Get("port_value")
+				endpointAddress := address.ToString() + ":" + portValue.ToString()
+				endpointAddresses[clusterName] = append(endpointAddresses[clusterName], endpointAddress)
+			}
+		}
+	}
+	return endpointAddresses, nil
+}


### PR DESCRIPTION
任务描述
该任务旨在监控所有KusciaTask（runC）在指定时间间隔内的系统资源使用情况，通过prometheus暴露指标，并统一导出到metricexporter模块。

功能需求
获取所有 KusciaTask 的接收字节数和发送字节数、接收带宽和发送带宽；
获取所有 KusciaTask 的CPU usage、Memory usage、Disk IO、Inode数；
将 container 和对应的 KusciaTask 关联起来；
通过prometheus暴露指标收集端点；
统一导出到metricexporter模块。
完成开发后，关联该 ISSUE 并提交代码至 https://github.com/secretflow/kuscia/;