### PR TITLE
【OSCP】【KUSCIA】文档「部署失败日志排查]、[Protocol 通信协议」翻译成英文文档

### DIFF
--- a/docs/locales/en/LC_MESSAGES/troubleshoot/concept/protocol_describe.po
+++ b/docs/locales/en/LC_MESSAGES/troubleshoot/concept/protocol_describe.po
@@ -19,46 +19,46 @@ msgstr ""
 
 #: ../../troubleshoot/concept/protocol_describe.md:1
 msgid "Protocol 通信协议"
-msgstr ""
+msgstr "Protocol Communication Protocol"
 
 #: ../../troubleshoot/concept/protocol_describe.md:3
 msgid "前言"
-msgstr ""
+msgstr "Introduction"
 
 #: ../../troubleshoot/concept/protocol_describe.md:5
 msgid ""
 "Protocol 是指 KusciaAPI "
 "以及节点对外网关使用的通信协议，有三种通信协议可供选择：NOTLS/TLS/MTLS（不区分大小写），详情请参考 [Kuscia "
 "配置文件](../../deployment/kuscia_config_cn.md#id3)。"
-msgstr ""
+msgstr "Protocol refers to the communication protocol used by KusciaAPI and node external gateway. There are three communication protocols available: NOTLS/TLS/MTLS (case-insensitive). For details, please refer to [Kuscia Configuration File](../../deployment/kuscia_config_cn.md#id3)."
 
 #: ../../troubleshoot/concept/protocol_describe.md:7
 msgid "不同 Protocol 对应的 KusciaAPI 请求"
-msgstr ""
+msgstr "KusciaAPI Requests for Different Protocols"
 
 #: ../../troubleshoot/concept/protocol_describe.md:9
 msgid ""
 "KusciaAPI 支持 NOTLS/TLS/MTLS 三种通信协议，在点对点和中心化部署模式中，KusciaAPI 接口默认使用的是 MTLS "
 "协议，不同协议使用 KusciaAPI 示例如下（此处以查询 domaindatasource 为例）："
-msgstr ""
+msgstr "KusciaAPI supports three communication protocols: NOTLS/TLS/MTLS. In peer-to-peer and centralized deployment modes, KusciaAPI interface uses MTLS protocol by default. Here are examples of using KusciaAPI with different protocols (using domaindatasource query as an example):"
 
 #: ../../troubleshoot/concept/protocol_describe.md:11
 msgid "NOTLS 协议下，KusciaAPI 接口使用 HTTP 协议，无需指定任何证书文件，示例如下："
-msgstr ""
+msgstr "Under NOTLS protocol, KusciaAPI interface uses HTTP protocol, no certificate files need to be specified. Example:"
 
 #: ../../troubleshoot/concept/protocol_describe.md:22
 msgid "MTLS 协议下，KusciaAPI 接口使用 HTTPS 协议，需要指定 TOKEN、CA 以及 KusciaAPI 证书文件，示例如下："
-msgstr ""
+msgstr "Under MTLS protocol, KusciaAPI interface uses HTTPS protocol, TOKEN, CA, and KusciaAPI certificate files need to be specified. Example:"
 
 #: ../../troubleshoot/concept/protocol_describe.md:37
 msgid ""
 "TLS协议下，KusciaAPI 接口使用 HTTPS 协议，需要指定 TOKEN、CA 证书文件，无需指定 KusciaAPI "
 "证书文件，示例如下："
-msgstr ""
+msgstr "Under TLS protocol, KusciaAPI interface uses HTTPS protocol, TOKEN and CA certificate files need to be specified, but KusciaAPI certificate file is not required. Example:"
 
 #: ../../troubleshoot/concept/protocol_describe.md:50
 msgid "不同 Protocol 对应的节点授权"
-msgstr ""
+msgstr "Node Authorization for Different Protocols"
 
 #: ../../troubleshoot/concept/protocol_describe.md:52
 msgid ""
@@ -66,11 +66,11 @@ msgid ""
 "配置文件](../../deployment/kuscia_config_cn.md#id3)。当本节点配置的 Protocol 为 "
 "TLS/MTLS 时，对端节点访问本节点使用 HTTPS 协议，当本节点配置的 Protocol 为 NOTLS 时，对端节点访问本节点使用 "
 "HTTP 协议，如下图所示。 ![protocol_describe](../../imgs/protocol_describe.png)"
-msgstr ""
+msgstr "For protocol types supported by Kuscia, please refer to [Kuscia Configuration File](../../deployment/kuscia_config_cn.md#id3). When the Protocol of this node is configured as TLS/MTLS, peer nodes access this node using HTTPS protocol. When the Protocol is configured as NOTLS, peer nodes access this node using HTTP protocol, as shown in the following figure. ![protocol_describe](../../imgs/protocol_describe.png)"
 
 #: ../../troubleshoot/concept/protocol_describe.md:52
 msgid "protocol_describe"
-msgstr ""
+msgstr "protocol_describe"
 
 #: ../../troubleshoot/concept/protocol_describe.md:55
 msgid ""
@@ -80,27 +80,26 @@ msgid ""
 " master 节点配置为 TLS 协议，lite 节点配置为 NOTLS 协议，即 lite 节点之间使用 HTTP 协议进行通信，lite "
 "访问 master 使用 HTTPS 协议进行通信，如下图所示。 "
 "![default_protocol](../../imgs/default_protocol.png)"
-msgstr ""
+msgstr "In the [Peer-to-Peer Mode Deployment](../../deployment/Docker_deployment_kuscia/deploy_p2p_cn.md) documentation, the default node configuration is TLS protocol, meaning nodes communicate with each other using HTTPS protocol. In the [Centralized Mode Deployment](../../deployment/Docker_deployment_kuscia/deploy_master_lite_cn.md) documentation, the master node is configured with TLS protocol by default, while lite nodes are configured with NOTLS protocol. This means lite nodes communicate with each other using HTTP protocol, and lite nodes access the master using HTTPS protocol, as shown in the following figure. ![default_protocol](../../imgs/default_protocol.png)"
 
 #: ../../troubleshoot/concept/protocol_describe.md:55
 msgid "default_protocol"
-msgstr ""
+msgstr "default_protocol"
 
 #: ../../troubleshoot/concept/protocol_describe.md:58
 msgid "修改 Protocol 的影响以及解决方法"
-msgstr ""
+msgstr "Impact and Solutions for Modifying Protocol"
 
 #: ../../troubleshoot/concept/protocol_describe.md:60
 msgid ""
 "用户在修改 [Kuscia 配置文件](../../deployment/kuscia_config_cn.md#id4)中的 Protocol "
 "协议之后，会导致 KusciaAPI 使用方式变化以及节点间的路由状态变为不可用，使用以下方法进行解决："
-msgstr ""
+msgstr "After modifying the Protocol in [Kuscia Configuration File](../../deployment/kuscia_config_cn.md#id4), it will cause changes in KusciaAPI usage and make the routing status between nodes unavailable. Use the following methods to resolve:"
 
 #: ../../troubleshoot/concept/protocol_describe.md:62
 msgid "KusciaApi 调用方式参考上述[不同 Protocol 对应的 KusciaAPI 请求](#protocol-kusciaapi)进行调整。"
-msgstr ""
+msgstr "Adjust the KusciaAPI calling method according to the above [KusciaAPI Requests for Different Protocols](#protocol-kusciaapi)."
 
 #: ../../troubleshoot/concept/protocol_describe.md:63
 msgid "通过 KusciaAPI 删除节点路由，按照上述[不同 Protocol 对应的节点授权](#id2)再重新创建。"
-msgstr ""
-
+msgstr "Delete node routes through KusciaAPI and recreate them according to the above [Node Authorization for Different Protocols](#id2)."

--- a/docs/locales/en/LC_MESSAGES/troubleshoot/concept/protocol_describe.po
+++ b/docs/locales/en/LC_MESSAGES/troubleshoot/concept/protocol_describe.po
@@ -19,7 +19,7 @@ msgstr ""
 
 #: ../../troubleshoot/concept/protocol_describe.md:1
 msgid "Protocol 通信协议"
-msgstr "Protocol Communication Protocol"
+msgstr "Communication Protocol"
 
 #: ../../troubleshoot/concept/protocol_describe.md:3
 msgid "前言"

--- a/docs/locales/en/LC_MESSAGES/troubleshoot/deployment/deploy_failed.po
+++ b/docs/locales/en/LC_MESSAGES/troubleshoot/deployment/deploy_failed.po
@@ -19,45 +19,44 @@ msgstr ""
 
 #: ../../troubleshoot/deployment/deploy_failed.md:1
 msgid "部署失败日志排查"
-msgstr ""
+msgstr "Deployment Failure Log Troubleshooting"
 
 #: ../../troubleshoot/deployment/deploy_failed.md:3
 msgid "排查步骤"
-msgstr ""
+msgstr "Troubleshooting Steps"
 
 #: ../../troubleshoot/deployment/deploy_failed.md:5
 msgid "检查机器配置"
-msgstr ""
+msgstr "Check Machine Configuration"
 
 #: ../../troubleshoot/deployment/deploy_failed.md:7
 msgid ""
 "若机器不满足[官网推荐配置](https://www.secretflow.org.cn/docs/kuscia/latest/zh-"
 "Hans/getting_started/quickstart_cn#id2)，可能会造成部分服务无法正常工作，从而导致部署失败。"
-msgstr ""
+msgstr "If the machine does not meet the [official recommended configuration](https://www.secretflow.org.cn/docs/kuscia/latest/getting_started/quickstart#id2), some services may not work properly, leading to deployment failure."
 
 #: ../../troubleshoot/deployment/deploy_failed.md:9
 msgid "查看服务日志"
-msgstr ""
+msgstr "View Service Logs"
 
 #: ../../troubleshoot/deployment/deploy_failed.md:11
 msgid "中心化组网模式"
-msgstr ""
+msgstr "Centralized Networking Mode"
 
 #: ../../troubleshoot/deployment/deploy_failed.md:13
 msgid "查看 Master 日志"
-msgstr ""
+msgstr "View Master Logs"
 
 #: ../../troubleshoot/deployment/deploy_failed.md:26
 #: ../../troubleshoot/deployment/deploy_failed.md:48
 msgid "查看 Alice 节点日志"
-msgstr ""
+msgstr "View Alice Node Logs"
 
 #: ../../troubleshoot/deployment/deploy_failed.md:36
 #: ../../troubleshoot/deployment/deploy_failed.md:61
 msgid "查看 Bob 节点日志"
-msgstr ""
+msgstr "View Bob Node Logs"
 
 #: ../../troubleshoot/deployment/deploy_failed.md:46
 msgid "点对点组网模式"
-msgstr ""
-
+msgstr "Peer-to-Peer Networking Mode"

--- a/docs/troubleshoot/deployment/deploy_failed.md
+++ b/docs/troubleshoot/deployment/deploy_failed.md
@@ -13,33 +13,33 @@
 查看 Master 日志
 
 ```shell
-# 登陆到 master 容器中
+# Log in to the master container
 docker exec -it ${USER}-kuscia-master bash
 
-# 查看 kuscia 错误日志
+# View kuscia error logs
 cat /home/kuscia/var/logs/kuscia.log | grep -i error
 
-# 查看 k3s 错误日志
+# View k3s error logs
 cat /home/kuscia/var/logs/k3s.log | grep -i error
 ```
 
 查看 Alice 节点日志
 
 ```shell
-# 登陆到 alice 容器中
+# Log in to the alice container
 docker exec -it ${USER}-kuscia-lite-alice bash
 
-# 查看 kuscia 错误日志
+# View kuscia error logs
 cat /home/kuscia/var/logs/kuscia.log | grep -i error
 ```
 
 查看 Bob 节点日志
 
 ```shell
-# 登陆到 bob 容器中
+# Log in to the bob container
 docker exec -it ${USER}-kuscia-lite-bob bash
 
-# 查看 kuscia 错误日志
+# View kuscia error logs
 cat /home/kuscia/var/logs/kuscia.log | grep -i error
 ```
 
@@ -48,26 +48,26 @@ cat /home/kuscia/var/logs/kuscia.log | grep -i error
 查看 Alice 节点日志
 
 ```shell
-# 登陆到 alice 容器中
+# Log in to the alice container
 docker exec -it ${USER}-kuscia-autonomy-alice bash
 
-# 查看 kuscia 错误日志
+# View kuscia error logs
 cat /home/kuscia/var/logs/kuscia.log | grep -i error
 
-# 查看 k3s 错误日志
+# View k3s error logs
 cat /home/kuscia/var/logs/k3s.log | grep -i error
 ```
 
 查看 Bob 节点日志
 
 ```shell
-# 登陆到 bob 容器中
+# Log in to the bob container
 docker exec -it ${USER}-kuscia-autonomy-bob bash
 
-# 查看 kuscia 错误日志
+# View kuscia error logs
 cat /home/kuscia/var/logs/kuscia.log | grep -i error
 
-# 查看 K3s 错误日志
+# View k3s error logs
 cat /home/kuscia/var/logs/k3s.log | grep -i error
 ```
 


### PR DESCRIPTION
Fixed #583 
由于之前的pr告诉我代码注释需要去原始md文件进行翻译，因为这个文件的log的注释也是用中文写的，所有我采取了和之前翻译中文代码注释一样的处理方式，我对原始的文件里面的中文注释翻译成了英文