### PR TITLE
test: simplify mock with xgo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ bazel-*
 .DS_Store
 
 **.mo
+# xgo
+**/.xgo/gen

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/stathat/consistent v1.0.0
 	github.com/stretchr/testify v1.9.0
 	github.com/tidwall/match v1.1.1
+	github.com/xhd2015/xgo/runtime v1.1.2
 	gitlab.com/jonas.jasas/condchan v0.0.0-20190210165812-36637ad2b5bc
 	go.uber.org/atomic v1.11.0
 	go.uber.org/zap v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -1341,6 +1341,12 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
 github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
+github.com/xhd2015/xgo/runtime v1.1.0 h1:mC8VszBnvYQLA4IKUyxqUIo1OheesqcAKrSLt/pkncw=
+github.com/xhd2015/xgo/runtime v1.1.0/go.mod h1:9GBQ2SzJCzpD3T+HRN+2C0TUOGv7qIz4s0mad1xJ8Jo=
+github.com/xhd2015/xgo/runtime v1.1.1 h1:R1GUKbjCxBba5KFOBrYSue7Lgn/imRFaO9NcuQcBfhs=
+github.com/xhd2015/xgo/runtime v1.1.1/go.mod h1:9GBQ2SzJCzpD3T+HRN+2C0TUOGv7qIz4s0mad1xJ8Jo=
+github.com/xhd2015/xgo/runtime v1.1.2 h1:KdyJti7O1fxFkrIwEbfLfJYXMF4VZ1v3lqvrH/1Fbd0=
+github.com/xhd2015/xgo/runtime v1.1.2/go.mod h1:9GBQ2SzJCzpD3T+HRN+2C0TUOGv7qIz4s0mad1xJ8Jo=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/diagnose/app/netstat/bandwidth_test.go
+++ b/pkg/diagnose/app/netstat/bandwidth_test.go
@@ -16,12 +16,11 @@ package netstat
 
 import (
 	"net/http"
-	"reflect"
 	"testing"
 
-	"github.com/agiledragon/gomonkey"
 	"github.com/secretflow/kuscia/pkg/diagnose/app/client"
 	"github.com/secretflow/kuscia/pkg/diagnose/common"
+	"github.com/xhd2015/xgo/runtime/mock"
 	"golang.org/x/net/context"
 	"gotest.tools/v3/assert"
 )
@@ -40,10 +39,9 @@ func TestBandWidth(t *testing.T) {
 			cli := client.NewDiagnoseClient("")
 			task := NewBandWidthTask(cli, 20)
 			bwTask := task.(*BandWidthTask)
-			patch := gomonkey.ApplyMethod(reflect.TypeOf(bwTask), "RecordData", func(_ *BandWidthTask, resp *http.Response) int {
+			mock.Patch(bwTask.RecordData, func(resp *http.Response) int {
 				return 100
 			})
-			defer patch.Reset()
 
 			bwTask.Run(context.Background())
 			assert.Equal(t, bwTask.output.Result, tt.result)

--- a/pkg/diagnose/app/netstat/latency_test.go
+++ b/pkg/diagnose/app/netstat/latency_test.go
@@ -15,14 +15,13 @@
 package netstat
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
-	"github.com/agiledragon/gomonkey"
 	"github.com/secretflow/kuscia/pkg/diagnose/app/client"
 	"github.com/secretflow/kuscia/pkg/diagnose/common"
 	"github.com/secretflow/kuscia/proto/api/v1alpha1/diagnose"
+	"github.com/xhd2015/xgo/runtime/mock"
 	"golang.org/x/net/context"
 	"gotest.tools/v3/assert"
 )
@@ -42,11 +41,10 @@ func TestLatency(t *testing.T) {
 			task := NewLatencyTask(cli, 20)
 			latencyTask := task.(*LatencyTask)
 
-			patches := gomonkey.ApplyMethod(reflect.TypeOf(cli), "Mock", func(_ *client.Client, ctx context.Context, request *diagnose.MockRequest) (response *diagnose.MockResponse, err error) {
+			mock.Patch(cli.Mock, func(ctx context.Context, request *diagnose.MockRequest) (response *diagnose.MockResponse, err error) {
 				time.Sleep(time.Duration(tt.latency) * time.Millisecond)
 				return nil, nil
 			})
-			defer patches.Reset()
 			latencyTask.Run(context.Background())
 			assert.Equal(t, latencyTask.output.Result, tt.result)
 		})

--- a/pkg/diagnose/app/netstat/proxytimeout_test.go
+++ b/pkg/diagnose/app/netstat/proxytimeout_test.go
@@ -16,13 +16,12 @@ package netstat
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
-	"github.com/agiledragon/gomonkey"
 	"github.com/secretflow/kuscia/pkg/diagnose/app/client"
 	"github.com/secretflow/kuscia/pkg/diagnose/common"
 	"github.com/secretflow/kuscia/proto/api/v1alpha1/diagnose"
+	"github.com/xhd2015/xgo/runtime/mock"
 	"golang.org/x/net/context"
 	"gotest.tools/v3/assert"
 )
@@ -42,13 +41,12 @@ func TestProxyTask(t *testing.T) {
 			cli := client.NewDiagnoseClient("")
 			threshold := 2
 			task := NewProxyTimeoutTask(cli, threshold).(*ProxyTimeoutTask)
-			patches := gomonkey.ApplyMethod(reflect.TypeOf(cli), "Mock", func(_ *client.Client, ctx context.Context, request *diagnose.MockRequest) (response *diagnose.MockResponse, err error) {
+			mock.Patch(cli.Mock, func(ctx context.Context, request *diagnose.MockRequest) (response *diagnose.MockResponse, err error) {
 				if tt.duration > threshold {
 					return nil, fmt.Errorf("server timeout")
 				}
 				return nil, nil
 			})
-			defer patches.Reset()
 			task.Run(context.Background())
 			assert.Equal(t, task.output.Result, tt.result)
 		})

--- a/pkg/diagnose/app/netstat/request_size_test.go
+++ b/pkg/diagnose/app/netstat/request_size_test.go
@@ -16,13 +16,12 @@ package netstat
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
-	"github.com/agiledragon/gomonkey"
 	"github.com/secretflow/kuscia/pkg/diagnose/app/client"
 	"github.com/secretflow/kuscia/pkg/diagnose/common"
 	"github.com/secretflow/kuscia/proto/api/v1alpha1/diagnose"
+	"github.com/xhd2015/xgo/runtime/mock"
 	"golang.org/x/net/context"
 	"gotest.tools/v3/assert"
 )
@@ -42,13 +41,13 @@ func TestRequestSizeTask(t *testing.T) {
 			cli := client.NewDiagnoseClient("")
 			threshold := 2
 			task := NewReqSizeTask(cli, threshold).(*ReqSizeTask)
-			patches := gomonkey.ApplyMethod(reflect.TypeOf(cli), "Mock", func(_ *client.Client, ctx context.Context, request *diagnose.MockRequest) (response *diagnose.MockResponse, err error) {
+
+			mock.Patch(cli.Mock, func(ctx context.Context, request *diagnose.MockRequest) (response *diagnose.MockResponse, err error) {
 				if tt.size > threshold {
 					return nil, fmt.Errorf("server timeout")
 				}
 				return nil, nil
 			})
-			defer patches.Reset()
 			task.Run(context.Background())
 			assert.Equal(t, task.output.Result, tt.result)
 		})

--- a/pkg/diagnose/mods/domain_route_test.go
+++ b/pkg/diagnose/mods/domain_route_test.go
@@ -17,13 +17,12 @@ package mods
 import (
 	"context"
 	"errors"
-	"reflect"
 	"testing"
 
-	"github.com/agiledragon/gomonkey/v2"
 	"github.com/secretflow/kuscia/pkg/diagnose/app/netstat"
 	"github.com/secretflow/kuscia/pkg/diagnose/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/xhd2015/xgo/runtime/mock"
 )
 
 func TestDomainRouteMod(t *testing.T) {
@@ -41,15 +40,13 @@ func TestDomainRouteMod(t *testing.T) {
 	mod := NewDomainRouteMod(reporter, nil, conf)
 	drMod := mod.(*DomainRouteMod)
 
-	patch1 := gomonkey.ApplyMethod(reflect.TypeOf(drMod.crdMod), "Run", func(_ *CRDMod, ctx context.Context) error {
+	mock.Patch(drMod.crdMod.Run, func(ctx context.Context) error {
 		return nil
 	})
-	defer patch1.Reset()
 
-	patch2 := gomonkey.ApplyMethod(reflect.TypeOf(drMod.taskGroup), "Start", func(_ *netstat.TaskGroup, ctx context.Context) ([]*netstat.TaskOutput, error) {
+	mock.Patch(drMod.taskGroup.Start, func(ctx context.Context) ([]*netstat.TaskOutput, error) {
 		return nil, nil
 	})
-	defer patch2.Reset()
 
 	err := mod.Run(context.Background())
 	assert.Nil(t, err)
@@ -70,15 +67,13 @@ func TestDomainRouteModFail(t *testing.T) {
 	mod := NewDomainRouteMod(reporter, nil, conf)
 	drMod := mod.(*DomainRouteMod)
 
-	patch1 := gomonkey.ApplyMethod(reflect.TypeOf(drMod.crdMod), "Run", func(_ *CRDMod, ctx context.Context) error {
+	mock.Patch(drMod.crdMod.Run, func(ctx context.Context) error {
 		return nil
 	})
-	defer patch1.Reset()
 
-	patch2 := gomonkey.ApplyMethod(reflect.TypeOf(drMod.taskGroup), "Start", func(_ *netstat.TaskGroup, ctx context.Context) ([]*netstat.TaskOutput, error) {
+	mock.Patch(drMod.taskGroup.Start, func(ctx context.Context) ([]*netstat.TaskOutput, error) {
 		return nil, errors.New("")
 	})
-	defer patch2.Reset()
 
 	err := mod.Run(context.Background())
 	assert.NotNil(t, err)

--- a/pkg/diagnose/mods/network_test.go
+++ b/pkg/diagnose/mods/network_test.go
@@ -16,13 +16,12 @@ package mods
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
-	"github.com/agiledragon/gomonkey"
 	"github.com/secretflow/kuscia/pkg/diagnose/app/netstat"
 	"github.com/secretflow/kuscia/pkg/diagnose/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/xhd2015/xgo/runtime/mock"
 )
 
 func TestNetworkMod(t *testing.T) {
@@ -40,10 +39,10 @@ func TestNetworkMod(t *testing.T) {
 	mod := NewNetworkMod(reporter, nil, conf)
 	netMod := mod.(*NetworkMod)
 
-	patch1 := gomonkey.ApplyMethod(reflect.TypeOf(netMod.cdrMod), "Run", func(_ *DomainRouteMod, ctx context.Context) error {
+	mock.Patch(netMod.cdrMod.Run, func(ctx context.Context) error {
 		return nil
 	})
-	defer patch1.Reset()
+
 	err := mod.Run(context.Background())
 	assert.Nil(t, err)
 }

--- a/pkg/gateway/controller/register_node_test.go
+++ b/pkg/gateway/controller/register_node_test.go
@@ -25,8 +25,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
-
-	gomonkeyv2 "github.com/agiledragon/gomonkey/v2"
+	"github.com/xhd2015/xgo/runtime/mock"
 
 	"github.com/secretflow/kuscia/cmd/kuscia/confloader"
 	"github.com/secretflow/kuscia/pkg/gateway/utils"
@@ -89,7 +88,7 @@ func TestRegisterDomain_ServerNotExists(t *testing.T) {
 	csr, key := generateTestKey(t, utAlice)
 
 	// try to mock http request
-	gomonkeyv2.ApplyFunc(utils.DoHTTPWithRetry, func(i interface{}, out interface{}, hp *utils.HTTPParam, d time.Duration, tm int) error {
+	mock.Patch(utils.DoHTTPWithRetry, func(i interface{}, out interface{}, hp *utils.HTTPParam, d time.Duration, tm int) error {
 		assert.Equal(t, http.MethodPost, hp.Method)
 		assert.Equal(t, utAlice, hp.KusciaSource)
 		return nil

--- a/scripts/make/golang.mk
+++ b/scripts/make/golang.mk
@@ -45,8 +45,9 @@ test:
 	rm -rf ./test-results
 	mkdir -p test-results
 
-	GOEXPERIMENT=nocoverageredesign go test $$(go list ./cmd/... | grep -Ev ${CMD_EXCLUDE_TESTS}) --parallel 4 -gcflags="all=-N -l" -coverprofile=test-results/cmd.covprofile.out | tee test-results/cmd.output.txt
-	GOEXPERIMENT=nocoverageredesign go test $$(go list ./pkg/... | grep -Ev ${PKG_EXCLUDE_TESTS}) --parallel 4 -gcflags="all=-N -l" -coverprofile=test-results/pkg.covprofile.out | tee test-results/pkg.output.txt
+	go install github.com/xhd2015/xgo/cmd/xgo@latest
+	GOEXPERIMENT=nocoverageredesign xgo test $$(go list ./cmd/... | grep -Ev ${CMD_EXCLUDE_TESTS}) --parallel 4 -coverprofile=test-results/cmd.covprofile.out | tee test-results/cmd.output.txt
+	GOEXPERIMENT=nocoverageredesign xgo test $$(go list ./pkg/... | grep -Ev ${PKG_EXCLUDE_TESTS}) --parallel 4 -coverprofile=test-results/pkg.covprofile.out | tee test-results/pkg.output.txt
 
 	cat ./test-results/cmd.output.txt | go-junit-report > ./test-results/TEST-cmd.xml
 	cat ./test-results/pkg.output.txt | go-junit-report > ./test-results/TEST-pkg.xml


### PR DESCRIPTION
# Writing Ahead
First, it's surprising that this project has got so many tests, it's really good!

# Overview
This PR tries to use `xgo` to setup mock as a replacement to `gomonkey`.

`xgo` has unified and more intuitive API for mock patching, and is built-in concurrent safe.

Before, use `gomonkey`:

```go
patches := gomonkey.ApplyMethod(reflect.TypeOf(obj), "Method", func(...) {
   ...
})
defer patches.Reset()
```

After, use `xgo`:
```go
mock.Patch((*Type).Method, func(...) {
   ...
})
```

Test result:
```sh
$ go install github.com/xhd2015/xgo/cmd/xgo@latest
$ xgo test -run TestK8sLogManager/mainWorker -v ./pkg/agent/provider/pod
=== RUN   TestK8sLogManager
=== RUN   TestK8sLogManager/mainWorker
--- PASS: TestK8sLogManager (1.00s)
    --- PASS: TestK8sLogManager/mainWorker (1.00s)
PASS
ok      github.com/secretflow/kuscia/pkg/agent/provider/pod     1.750s
```

Comparison:

|  | xgo | gomonkey |
|-----|----------|-------------|
|Setup| `go install github.com/xhd2015/xgo/cmd/xgo@latest` and `xgo test` | MacOS: `permission denied`, need extra setup |
|Mock| `Patch` | `Apply*`+`reflect` |
|Cleanup| no need, mock is per-test based| `defer patches.Reset()`|
|Type Safety| Y | N(using `reflect`) |
|Concurrent Safety| Y | N, random failure|
|Build constraint| None| `-gcflags=all=-l`|
|Arch| All | amd64, partially arm64  |

That said, `gomonkey` is somehow overheaded, `xgo` just feels the natural way.

# Rationale
When a contributor clones the repository and tries to run the unit test, probably will encounter the following failure:
```sh
$ go test -run TestK8sLogManager/mainWorker -v ./pkg/agent/provider/pod
=== RUN   TestK8sLogManager
=== RUN   TestK8sLogManager/mainWorker
Starting k8s log manager
Waiting for informer cache to sync
--- FAIL: TestK8sLogManager (0.00s)
    --- FAIL: TestK8sLogManager/mainWorker (0.00s)
panic: permission denied [recovered]
        panic: permission denied
...
```

This is just the one issue `gomonkey` brings.

There are many common issues `gomonkey` suffers from, inherited from its unsafe binary replacement strategy.

Looking into https://github.com/agiledragon/gomonkey/issues, fews are common:
- Random failure: https://github.com/agiledragon/gomonkey/issues/171
- Permission denied: https://github.com/agiledragon/gomonkey/issues/142
- Bad arm64 support: https://github.com/agiledragon/gomonkey/issues/87
- ...

~~For preview purpose, currently only one test is replaced. I will replace more tests later.~~