### PR TITLE
【OSCP】【KUSCIA】修改 diagnose 在某些情况下输出过长的问题

### DIFF
--- a/pkg/diagnose/app/client/client.go
+++ b/pkg/diagnose/app/client/client.go
@@ -62,18 +62,18 @@ func (c *Client) invokeProto(ctx context.Context, request proto.Message, respons
 		var err error
 		byteReq, err = proto.Marshal(request)
 		if err != nil {
-			nlog.Errorf("Send request %+v ,marshal request failed: %s", request, err.Error())
+			nlog.Errorf("Marshal request failed: %s", err.Error())
 			return err
 		}
 	}
 	byteBody, err := c.invokeProtoRequest(ctx, method, path, byteReq)
 	if err != nil {
-		nlog.Errorf("Send request %+v failed: %s", request, err.Error())
+		nlog.Errorf("Invoke proto request failed: %s", err.Error())
 		return err
 	}
 	err = proto.Unmarshal(byteBody, response)
 	if err != nil {
-		nlog.Errorf("Send request %+v ,Unmarshal response body %s failed: %s", request, byteBody, err.Error())
+		nlog.Errorf("Unmarshal response body failed: %s", err.Error())
 		return err
 	}
 	return nil


### PR DESCRIPTION
当前版本在`REQUEST_BODY_SIZE`诊断中会将整个失败的请求的请求体全部输出， 在最后输出错误代码为 `413`。此处过长且无法停止(ctrl + c 无法终止, 因为是`stdout`瓶颈)会给用户带来恐慌感。
![image](https://github.com/user-attachments/assets/06a29a8c-65bb-40e3-9dcd-b2acdf9f146d)
![image](https://github.com/user-attachments/assets/23a2b4a8-e5d0-449b-ac27-3a99677af0ea)

Fixed #522 


