### PR TITLE
feat: aggregate job error messages from failed tasks and parties

### DIFF
--- a/pkg/kusciaapi/service/job_service_test.go
+++ b/pkg/kusciaapi/service/job_service_test.go
@@ -215,9 +215,9 @@ func TestBuildScheduleConfigForKusciaAPI(t *testing.T) {
 }
 
 func TestAggregateErrorMessage(t *testing.T) {
-	// 创建 jobService 实例用于测试
+	// Create jobService instance for testing
 	js := &jobService{}
-	
+
 	tests := []struct {
 		name     string
 		jobMsg   string
@@ -325,7 +325,7 @@ func TestAggregateErrorMessage(t *testing.T) {
 						{
 							DomainId: "bob",
 							State:    kusciaapi.JobState_Succeeded.String(),
-							ErrMsg:   "", // 成功的party不应该有错误信息
+							ErrMsg:   "", // Successful party should not have error message
 						},
 					},
 				},
@@ -344,7 +344,7 @@ func TestAggregateErrorMessage(t *testing.T) {
 						{
 							DomainId: "alice",
 							State:    kusciaapi.JobState_Failed.String(),
-							ErrMsg:   "", // 空错误信息应该被忽略
+							ErrMsg:   "", // Empty error message should be ignored
 						},
 					},
 				},

--- a/pkg/kusciaapi/service/job_service_test.go
+++ b/pkg/kusciaapi/service/job_service_test.go
@@ -213,3 +213,150 @@ func TestBuildScheduleConfigForKusciaAPI(t *testing.T) {
 		})
 	}
 }
+
+func TestAggregateErrorMessage(t *testing.T) {
+	// 创建 jobService 实例用于测试
+	js := &jobService{}
+	
+	tests := []struct {
+		name     string
+		jobMsg   string
+		jobPhase v1alpha1.KusciaJobPhase
+		tasks    []*kusciaapi.TaskStatus
+		want     string
+	}{
+		{
+			name:     "job message not empty should return original message",
+			jobMsg:   "original job error",
+			jobPhase: v1alpha1.KusciaJobFailed,
+			tasks:    []*kusciaapi.TaskStatus{},
+			want:     "original job error",
+		},
+		{
+			name:     "job phase not failed should return original message",
+			jobMsg:   "",
+			jobPhase: v1alpha1.KusciaJobRunning,
+			tasks:    []*kusciaapi.TaskStatus{},
+			want:     "",
+		},
+		{
+			name:     "no failed tasks should return original message",
+			jobMsg:   "",
+			jobPhase: v1alpha1.KusciaJobFailed,
+			tasks: []*kusciaapi.TaskStatus{
+				{
+					Alias: "task1",
+					State: kusciaapi.JobState_Succeeded.String(),
+					Parties: []*kusciaapi.PartyStatus{
+						{DomainId: "alice", State: kusciaapi.JobState_Succeeded.String()},
+					},
+				},
+			},
+			want: "",
+		},
+		{
+			name:     "single task single party failed",
+			jobMsg:   "",
+			jobPhase: v1alpha1.KusciaJobFailed,
+			tasks: []*kusciaapi.TaskStatus{
+				{
+					Alias: "task1",
+					State: kusciaapi.JobState_Failed.String(),
+					Parties: []*kusciaapi.PartyStatus{
+						{
+							DomainId: "alice",
+							State:    kusciaapi.JobState_Failed.String(),
+							ErrMsg:   "connection timeout",
+						},
+					},
+				},
+			},
+			want: "Task[task1]-Party[alice]: connection timeout",
+		},
+		{
+			name:     "multiple tasks multiple parties failed",
+			jobMsg:   "",
+			jobPhase: v1alpha1.KusciaJobFailed,
+			tasks: []*kusciaapi.TaskStatus{
+				{
+					Alias: "task1",
+					State: kusciaapi.JobState_Failed.String(),
+					Parties: []*kusciaapi.PartyStatus{
+						{
+							DomainId: "alice",
+							State:    kusciaapi.JobState_Failed.String(),
+							ErrMsg:   "connection timeout",
+						},
+						{
+							DomainId: "bob",
+							State:    kusciaapi.JobState_Failed.String(),
+							ErrMsg:   "resource insufficient",
+						},
+					},
+				},
+				{
+					Alias: "task2",
+					State: kusciaapi.JobState_Failed.String(),
+					Parties: []*kusciaapi.PartyStatus{
+						{
+							DomainId: "charlie",
+							State:    kusciaapi.JobState_Failed.String(),
+							ErrMsg:   "data validation error",
+						},
+					},
+				},
+			},
+			want: "Task[task1]-Party[alice]: connection timeout; Task[task1]-Party[bob]: resource insufficient; Task[task2]-Party[charlie]: data validation error",
+		},
+		{
+			name:     "mixed party states only failed parties reported",
+			jobMsg:   "",
+			jobPhase: v1alpha1.KusciaJobFailed,
+			tasks: []*kusciaapi.TaskStatus{
+				{
+					Alias: "task1",
+					State: kusciaapi.JobState_Failed.String(),
+					Parties: []*kusciaapi.PartyStatus{
+						{
+							DomainId: "alice",
+							State:    kusciaapi.JobState_Failed.String(),
+							ErrMsg:   "connection timeout",
+						},
+						{
+							DomainId: "bob",
+							State:    kusciaapi.JobState_Succeeded.String(),
+							ErrMsg:   "", // 成功的party不应该有错误信息
+						},
+					},
+				},
+			},
+			want: "Task[task1]-Party[alice]: connection timeout",
+		},
+		{
+			name:     "failed party with empty error message should be ignored",
+			jobMsg:   "",
+			jobPhase: v1alpha1.KusciaJobFailed,
+			tasks: []*kusciaapi.TaskStatus{
+				{
+					Alias: "task1",
+					State: kusciaapi.JobState_Failed.String(),
+					Parties: []*kusciaapi.PartyStatus{
+						{
+							DomainId: "alice",
+							State:    kusciaapi.JobState_Failed.String(),
+							ErrMsg:   "", // 空错误信息应该被忽略
+						},
+					},
+				},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := js.aggregateErrorMessage(tt.jobMsg, tt.jobPhase, tt.tasks)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Implement aggregateErrorMessage function to consolidate error information when KusciaJob fails. The function collects error messages from all failed tasks and parties, providing clearer job-level error reporting.

- Add aggregateErrorMessage method to jobService
- Integrate error aggregation into buildJobStatus
- Add comprehensive unit tests covering all edge cases
- Handle empty messages and mixed party states appropriately

Fixes #529