### PR TITLE
【OSCP】Kuscia images import 支持校验镜像架构是否匹配当前 Kuscia架构（runc、runp） (#733)

### DIFF
--- a/cmd/kuscia/utils/kuscia_image.go
+++ b/cmd/kuscia/utils/kuscia_image.go
@@ -20,6 +20,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -147,6 +148,11 @@ func (o *OciImage) RemoveImage() error {
 }
 
 func (o *OciImage) LoadImage(tarFile string) error {
+	currentPlatform := runtime.GOOS + "/" + runtime.GOARCH
+	currentPlatform = strings.ToLower(currentPlatform)
+	if err := ValidateArch(tarFile, currentPlatform); err != nil {
+		return fmt.Errorf("error: %s", err.Error())
+	}
 	return o.Store.LoadImage(tarFile)
 }
 
@@ -313,6 +319,11 @@ func (c *ContainerImage) RemoveImage() error {
 }
 
 func (c *ContainerImage) LoadImage(tarFile string) error {
+	currentPlatform := runtime.GOOS + "/" + runtime.GOARCH
+	currentPlatform = strings.ToLower(currentPlatform)
+	if err := ValidateArch(tarFile, currentPlatform); err != nil {
+		return fmt.Errorf("error: %s", err.Error())
+	}
 	return runContainerdCmd(c.cmd.Context(), "ctr", "--address", common.ContainerdSocket(), "--namespace", common.KusciaDefaultNamespaceOfContainerd, "images", "import", "--no-unpack", tarFile)
 }
 

--- a/cmd/kuscia/utils/tarfile_os_arch_reader.go
+++ b/cmd/kuscia/utils/tarfile_os_arch_reader.go
@@ -1,0 +1,414 @@
+package utils
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/secretflow/kuscia/pkg/utils/nlog"
+)
+
+type ArchInfo struct {
+	Architecture string `json:"architecture"`
+	OS           string `json:"os"`
+	Variant      string `json:"variant,omitempty"`
+	Ref          string `json:"ref"`
+	Source       string `json:"source"`
+}
+
+type ArchSummary struct {
+	Ref       string   `json:"ref"`
+	Platforms []string `json:"platforms"`
+}
+
+type OCIIndex struct {
+	SchemaVersion int                `json:"schemaVersion"`
+	MediaType     string             `json:"mediaType,omitempty"`
+	Manifests     []OCIIndexManifest `json:"manifests"`
+	Annotations   map[string]string  `json:"annotations,omitempty"`
+}
+
+type OCIIndexManifest struct {
+	MediaType   string            `json:"mediaType"`
+	Digest      string            `json:"digest"`
+	Size        int               `json:"size,omitempty"`
+	Platform    *OCIPlatform      `json:"platform,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+type OCIPlatform struct {
+	Architecture string `json:"architecture"`
+	OS           string `json:"os"`
+	Variant      string `json:"variant,omitempty"`
+}
+
+type OCIManifest struct {
+	SchemaVersion int               `json:"schemaVersion"`
+	MediaType     string            `json:"mediaType,omitempty"`
+	Config        OCIDescriptor     `json:"config"`
+	Layers        []OCIDescriptor   `json:"layers"`
+	Annotations   map[string]string `json:"annotations,omitempty"`
+}
+
+type OCIDescriptor struct {
+	MediaType   string            `json:"mediaType"`
+	Digest      string            `json:"digest"`
+	Size        int               `json:"size"`
+	URLs        []string          `json:"urls,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+type DockerManifest struct {
+	Config   string   `json:"Config"`
+	RepoTags []string `json:"RepoTags"`
+	Layers   []string `json:"Layers"`
+}
+
+type ImageConfig struct {
+	Architecture string `json:"architecture"`
+	OS           string `json:"os"`
+	Variant      string `json:"variant,omitempty"`
+}
+
+type TarReader struct {
+	filePath string
+	isGzip   bool
+}
+
+type TarfileOsArchUnsupportedError struct {
+	Source          string
+	CurrentPlatform string
+	ArchSummary     []ArchSummary
+	Cause           error
+}
+
+func (e *TarfileOsArchUnsupportedError) Error() string {
+	return fmt.Errorf("the image in tarfile %s: %+v, is not accepted by the current OS/Arch: %s, cause: %v", e.Source, e.ArchSummary, e.CurrentPlatform, e.Cause).Error()
+}
+
+func (e *TarfileOsArchUnsupportedError) Unwrap() error {
+	return e.Cause
+}
+
+func createTarReader(filePath string) *TarReader {
+	isGzip := strings.HasSuffix(strings.ToLower(filePath), ".gz")
+	isTarGzip := strings.HasSuffix(strings.ToLower(filePath), ".tgz")
+	return &TarReader{
+		filePath: filePath,
+		isGzip:   isGzip || isTarGzip,
+	}
+}
+
+func (tr *TarReader) ExtractFileToMemory(filePath string) ([]byte, error) {
+	file, err := os.Open(tr.filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file: %v", err)
+	}
+	defer file.Close()
+
+	var tarReader *tar.Reader
+	if tr.isGzip {
+		gzReader, err := gzip.NewReader(file)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create gzip reader: %v", err)
+		}
+		defer gzReader.Close()
+		tarReader = tar.NewReader(gzReader)
+	} else {
+		tarReader = tar.NewReader(file)
+	}
+
+	filePath = filepath.ToSlash(filePath)
+	filePath = strings.TrimPrefix(filePath, "./")
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to read tar entry: %v", err)
+		}
+
+		entryPath := filepath.ToSlash(header.Name)
+		entryPath = strings.TrimPrefix(entryPath, "./")
+
+		if entryPath == filePath {
+			if header.Typeflag != tar.TypeReg {
+				return nil, fmt.Errorf("file %s is not a regular file", filePath)
+			}
+
+			data, err := ioutil.ReadAll(tarReader)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read file content: %v", err)
+			}
+			return data, nil
+		}
+	}
+
+	file.Seek(0, 0)
+	if tr.isGzip {
+		gzReader, err := gzip.NewReader(file)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create gzip reader: %v", err)
+		}
+		defer gzReader.Close()
+		tarReader = tar.NewReader(gzReader)
+	} else {
+		tarReader = tar.NewReader(file)
+	}
+
+	lowerFilePath := strings.ToLower(filePath)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to read tar entry: %v", err)
+		}
+
+		entryPath := filepath.ToSlash(header.Name)
+		entryPath = strings.TrimPrefix(entryPath, "./")
+
+		if strings.ToLower(entryPath) == lowerFilePath {
+			if header.Typeflag != tar.TypeReg {
+				return nil, fmt.Errorf("file %s is not a regular file", entryPath)
+			}
+
+			data, err := ioutil.ReadAll(tarReader)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read file content: %v", err)
+			}
+			return data, nil
+		}
+	}
+
+	return nil, fmt.Errorf("file %s not found in tar archive", filePath)
+}
+
+func (tr *TarReader) ReadJSONFile(filePath string, v interface{}) error {
+	data, err := tr.ExtractFileToMemory(filePath)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(data, v)
+}
+
+type ArchReader struct {
+	tarReader *TarReader
+}
+
+func createArchReader(tarFilePath string) *ArchReader {
+	return &ArchReader{
+		tarReader: createTarReader(tarFilePath),
+	}
+}
+
+func (ar *ArchReader) detectArchitecture() ([]ArchInfo, error) {
+	var archInfos []ArchInfo
+
+	ociArch, err := ar.parseOCIIndex()
+	if err == nil && len(ociArch) > 0 {
+		archInfos = append(archInfos, ociArch...)
+	}
+
+	if len(archInfos) == 0 {
+		dockerArch, err := ar.parseDockerManifest()
+		if err == nil {
+			archInfos = append(archInfos, dockerArch...)
+		}
+	}
+
+	return archInfos, nil
+}
+
+func (ar *ArchReader) parseOCIIndex() ([]ArchInfo, error) {
+	var archInfos []ArchInfo
+	var index OCIIndex
+
+	err := ar.tarReader.ReadJSONFile("index.json", &index)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read index.json: %v", err)
+	}
+
+	for _, manifest := range index.Manifests {
+		var imageRefName, imageName, refName string
+		if manifest.Annotations != nil {
+			imageRefName = manifest.Annotations["org.opencontainers.image.ref.name"]
+			imageName = manifest.Annotations["io.containerd.image.name"]
+		}
+		if imageRefName != "" {
+			refName = imageRefName
+		}
+		if imageName != "" {
+			refName = imageName
+		}
+		// 如果索引中直接包含平台信息
+		if manifest.Platform != nil {
+			archInfos = append(archInfos, ArchInfo{
+				Architecture: manifest.Platform.Architecture,
+				OS:           manifest.Platform.OS,
+				Variant:      manifest.Platform.Variant,
+				Ref:          refName,
+				Source:       "index.json manifest platform",
+			})
+			continue
+		}
+
+		if manifest.Digest == "" || !strings.HasPrefix(manifest.Digest, "sha256:") {
+			continue
+		}
+
+		digestID := strings.TrimPrefix(manifest.Digest, "sha256:")
+		blobPath := fmt.Sprintf("blobs/sha256/%s", digestID)
+
+		switch manifest.MediaType {
+		case "application/vnd.oci.image.index.v1+json", "application/vnd.docker.distribution.manifest.list.v2+json":
+			var nestedIndex OCIIndex
+			err := ar.tarReader.ReadJSONFile(blobPath, &nestedIndex)
+			if err == nil {
+				for _, nestedManifest := range nestedIndex.Manifests {
+					if nestedManifest.Platform != nil {
+						archInfos = append(archInfos, ArchInfo{
+							Architecture: nestedManifest.Platform.Architecture,
+							OS:           nestedManifest.Platform.OS,
+							Variant:      nestedManifest.Platform.Variant,
+							Ref:          refName,
+							Source:       fmt.Sprintf("nested manifest index (%s)", manifest.MediaType),
+						})
+					}
+				}
+			}
+		case "application/vnd.oci.image.manifest.v1+json", "application/vnd.docker.distribution.manifest.v2+json":
+			var ociManifest OCIManifest
+			err := ar.tarReader.ReadJSONFile(blobPath, &ociManifest)
+			if err == nil {
+				configDigestID := strings.TrimPrefix(ociManifest.Config.Digest, "sha256:")
+				configBlobPath := fmt.Sprintf("blobs/sha256/%s", configDigestID)
+
+				var config ImageConfig
+				err := ar.tarReader.ReadJSONFile(configBlobPath, &config)
+				if err == nil {
+					archInfos = append(archInfos, ArchInfo{
+						Architecture: config.Architecture,
+						OS:           config.OS,
+						Variant:      config.Variant,
+						Ref:          refName,
+						Source:       fmt.Sprintf("manifest config (%s)", manifest.MediaType),
+					})
+				}
+			}
+		}
+	}
+
+	return archInfos, nil
+}
+
+func (ar *ArchReader) parseDockerManifest() ([]ArchInfo, error) {
+	var archInfos []ArchInfo
+	var manifests []DockerManifest
+
+	err := ar.tarReader.ReadJSONFile("manifest.json", &manifests)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read manifest.json: %v", err)
+	}
+
+	for _, manifest := range manifests {
+		if manifest.Config == "" {
+			continue
+		}
+
+		var config ImageConfig
+		err := ar.tarReader.ReadJSONFile(manifest.Config, &config)
+		if err == nil {
+			archInfos = append(archInfos, ArchInfo{
+				Architecture: config.Architecture,
+				OS:           config.OS,
+				Variant:      config.Variant,
+				Ref:          manifest.RepoTags[0],
+				Source:       "docker manifest.json config",
+			})
+		}
+	}
+
+	return archInfos, nil
+}
+
+func ReadOsArchFromImageTarFile(tarFile string) ([]ArchSummary, error) {
+	reader := createArchReader(tarFile)
+	archInfos, err := reader.detectArchitecture()
+	if err != nil {
+		nlog.Fatalf("Error detecting architecture: %v", err)
+		return nil, err
+	}
+	result := make([]ArchSummary, 0)
+
+	refMap := make(map[string][]string)
+	for _, arch := range archInfos {
+		osArch := fmt.Sprintf("%s/%s", arch.OS, arch.Architecture)
+		refMap[arch.Ref] = append(refMap[arch.Ref], osArch)
+	}
+
+	for ref, osArchs := range refMap {
+		result = append(result, ArchSummary{
+			Ref:       ref,
+			Platforms: osArchs,
+		})
+	}
+
+	return result, nil
+}
+
+func ValidateArch(tarFile string, currentPlatform string) error {
+	archSummary, err := ReadOsArchFromImageTarFile(tarFile)
+	if err != nil {
+		nlog.Warnf("Error reading image tar file: %s, error: %v", tarFile, err)
+	}
+	if len(archSummary) == 0 {
+		return &TarfileOsArchUnsupportedError{
+			Source:          tarFile,
+			CurrentPlatform: currentPlatform,
+			ArchSummary:     archSummary,
+			Cause:           errors.New("no architecture information found in the image tar file"),
+		}
+	}
+	if len(archSummary) > 1 {
+		return &TarfileOsArchUnsupportedError{
+			Source:          tarFile,
+			CurrentPlatform: currentPlatform,
+			ArchSummary:     archSummary,
+			Cause:           errors.New("only one image tag is allowed per load command"),
+		}
+	}
+	isCompatible := false
+	for _, osArch := range archSummary[0].Platforms {
+		normalized := osArch
+		if parts := strings.Split(osArch, "/"); len(parts) > 2 {
+			normalized = parts[0] + "/" + parts[1]
+		}
+		if normalized == currentPlatform {
+			isCompatible = true
+			break
+		}
+	}
+
+	if !isCompatible {
+		return &TarfileOsArchUnsupportedError{
+			Source:          tarFile,
+			CurrentPlatform: currentPlatform,
+			ArchSummary:     archSummary,
+			Cause:           errors.New("unsupported platform"),
+		}
+	}
+
+	return nil
+}

--- a/cmd/kuscia/utils/tarfile_os_arch_reader_test.go
+++ b/cmd/kuscia/utils/tarfile_os_arch_reader_test.go
@@ -1,0 +1,871 @@
+package utils
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type LegacyImageInput struct {
+	RepoTags     []string
+	Config       string
+	OS           string
+	Architecture string
+}
+
+type legacyImageInternal struct {
+	LegacyImageInput
+	Layers  []string
+	DiffIDs []string
+}
+
+type ociManifest struct {
+	SchemaVersion int                     `json:"schemaVersion"`
+	MediaType     string                  `json:"mediaType,omitempty"`
+	Manifests     []ociManifestDescriptor `json:"manifests"`
+}
+
+type ociManifestDescriptor struct {
+	MediaType   string            `json:"mediaType"`
+	Digest      string            `json:"digest"`
+	Size        int               `json:"size"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Platform    *PlatformInfo     `json:"platform,omitempty"`
+}
+
+type PlatformInfo struct {
+	Architecture string `json:"architecture"`
+	OS           string `json:"os"`
+}
+type archImage struct {
+	cfgHex   string
+	layerHex string
+	manHex   string
+	cfgBytes []byte
+	layerBuf []byte
+	manBytes []byte
+	arch     string
+	os       string
+}
+
+const tempImageTestDir = "kuscia-temp-image-test"
+
+func writeTarFile(w *tar.Writer, name string, content []byte) error {
+	hdr := &tar.Header{
+		Name:     name,
+		Mode:     0644,
+		Size:     int64(len(content)),
+		ModTime:  time.Now(),
+		Typeflag: tar.TypeReg,
+	}
+	if err := w.WriteHeader(hdr); err != nil {
+		return err
+	}
+	_, err := w.Write(content)
+	return err
+}
+
+func randomDigest(input string) string {
+	sum := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(sum[:])
+}
+
+func buildLayerTarGz(content string) (layerBytes []byte, diffID string, err error) {
+	var tarBuf bytes.Buffer
+	tw := tar.NewWriter(&tarBuf)
+
+	hdr := &tar.Header{
+		Name:    "message.txt",
+		Mode:    0644,
+		Size:    int64(len(content)),
+		ModTime: time.Now(),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return nil, "", err
+	}
+	if _, err := tw.Write([]byte(content)); err != nil {
+		return nil, "", err
+	}
+	if err := tw.Close(); err != nil {
+		return nil, "", err
+	}
+
+	uncompressedData := tarBuf.Bytes()
+	hash := sha256.Sum256(uncompressedData)
+	diffID = "sha256:" + hex.EncodeToString(hash[:])
+
+	var gzBuf bytes.Buffer
+	gzw := gzip.NewWriter(&gzBuf)
+	if _, err := gzw.Write(uncompressedData); err != nil {
+		return nil, "", err
+	}
+	if err := gzw.Close(); err != nil {
+		return nil, "", err
+	}
+
+	return gzBuf.Bytes(), diffID, nil
+}
+func buildArchImage(osArch string, tag string) (*archImage, error) {
+	parts := strings.Split(osArch, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid os/arch: %s", osArch)
+	}
+	osStr, archStr := parts[0], parts[1]
+
+	layerBytes, diffID, err := buildLayerTarGz(fmt.Sprintf("Hello from %s/%s", osStr, archStr))
+	if err != nil {
+		return nil, err
+	}
+	layerDigest := sha256.Sum256(layerBytes)
+
+	cfg := map[string]interface{}{
+		"architecture": archStr,
+		"os":           osStr,
+		"rootfs": map[string]interface{}{
+			"type":     "layers",
+			"diff_ids": []string{diffID},
+		},
+		"config": map[string]interface{}{},
+	}
+	cfgContent, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
+	cfgDigest := sha256.Sum256(cfgContent)
+
+	manifest := map[string]interface{}{
+		"schemaVersion": 2,
+		"mediaType":     "application/vnd.oci.image.manifest.v1+json",
+		"config": map[string]interface{}{
+			"mediaType": "application/vnd.oci.image.config.v1+json",
+			"digest":    "sha256:" + hex.EncodeToString(cfgDigest[:]),
+			"size":      len(cfgContent),
+		},
+		"layers": []map[string]interface{}{
+			{
+				"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+				"digest":    "sha256:" + hex.EncodeToString(layerDigest[:]),
+				"size":      len(layerBytes),
+			},
+		},
+	}
+	manBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, err
+	}
+	manDigest := sha256.Sum256(manBytes)
+
+	return &archImage{
+		cfgHex:   hex.EncodeToString(cfgDigest[:]),
+		layerHex: hex.EncodeToString(layerDigest[:]),
+		manHex:   hex.EncodeToString(manDigest[:]),
+		cfgBytes: cfgContent,
+		layerBuf: layerBytes,
+		manBytes: manBytes,
+		arch:     archStr,
+		os:       osStr,
+	}, nil
+}
+
+func createFakeLayerTar(fileName, content string) ([]byte, string, error) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	data := []byte(content)
+	hdr := &tar.Header{
+		Name: fileName,
+		Mode: 0644,
+		Size: int64(len(data)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return nil, "", err
+	}
+	if _, err := tw.Write(data); err != nil {
+		return nil, "", err
+	}
+	tw.Close()
+	diffID := sha256.Sum256(buf.Bytes())
+	diffIDStr := fmt.Sprintf("sha256:%x", diffID[:])
+	return buf.Bytes(), diffIDStr, nil
+}
+
+func createDockerLegacyTarball(outputPath string, images []LegacyImageInput) error {
+	tempDir, err := os.MkdirTemp("", "legacy-docker")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tempDir)
+
+	manifest := []map[string]interface{}{}
+	repoMap := map[string]map[string]string{}
+
+	buf := new(bytes.Buffer)
+	tarWriter := tar.NewWriter(buf)
+
+	for imgIdx, imgInput := range images {
+		image := legacyImageInternal{LegacyImageInput: imgInput}
+		image.Layers = []string{}
+		image.DiffIDs = []string{}
+
+		for i := 0; i < 2; i++ {
+			layerName := fmt.Sprintf("%s-layer-%d.tar", randomDigest(fmt.Sprintf("img-%d-%s-%d", imgIdx, strings.Join(imgInput.RepoTags, ","), i)), i)
+			tarContent, diffID, err := createFakeLayerTar("hello.txt", fmt.Sprintf("hello world %d\n", i))
+			if err != nil {
+				return err
+			}
+
+			image.Layers = append(image.Layers, layerName)
+			image.DiffIDs = append(image.DiffIDs, diffID)
+
+			if err := writeTarFile(tarWriter, layerName, tarContent); err != nil {
+				return err
+			}
+		}
+
+		configName := imgInput.Config
+		if configName == "" {
+			configName = randomDigest(fmt.Sprintf("img-%d-config", imgIdx)) + ".json"
+		}
+
+		configContent := map[string]interface{}{
+			"architecture": image.Architecture,
+			"os":           image.OS,
+			"config": map[string]interface{}{
+				"Env":        []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
+				"Entrypoint": []string{"docker-entrypoint.sh"},
+			},
+			"rootfs": map[string]interface{}{
+				"type":     "layers",
+				"diff_ids": image.DiffIDs,
+			},
+		}
+		configBytes, _ := json.Marshal(configContent)
+		if err := writeTarFile(tarWriter, configName, configBytes); err != nil {
+			return err
+		}
+
+		manifest = append(manifest, map[string]interface{}{
+			"Config":   configName,
+			"RepoTags": imgInput.RepoTags,
+			"Layers":   image.Layers,
+		})
+
+		for _, tag := range imgInput.RepoTags {
+			parts := strings.SplitN(tag, ":", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			repo := parts[0]
+			tagName := parts[1]
+			if _, ok := repoMap[repo]; !ok {
+				repoMap[repo] = map[string]string{}
+			}
+			repoMap[repo][tagName] = configName
+		}
+	}
+
+	manifestBytes, _ := json.MarshalIndent(manifest, "", "  ")
+	if err := writeTarFile(tarWriter, "manifest.json", manifestBytes); err != nil {
+		return err
+	}
+
+	repoBytes, _ := json.MarshalIndent(repoMap, "", "  ")
+	if err := writeTarFile(tarWriter, "repositories", repoBytes); err != nil {
+		return err
+	}
+
+	tarWriter.Close()
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(outputPath, buf.Bytes(), 0644)
+}
+
+func createMultiArchOCIImageFile(tarFile string, archTags [][]string, emitPlatformForIndexManifest bool) error {
+	tempRoot, err := os.MkdirTemp("", "oci-tmp-")
+	if err != nil {
+		return fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tempRoot)
+
+	if err := os.MkdirAll(filepath.Join(tempRoot, "blobs", "sha256"), 0755); err != nil {
+		return err
+	}
+
+	tagToImages := map[string][]*archImage{}
+
+	for _, pair := range archTags {
+		osArch := pair[0]
+		tag := pair[1]
+
+		img, err := buildArchImage(osArch, tag)
+		if err != nil {
+			return fmt.Errorf("buildArchImage failed: %w", err)
+		}
+
+		for _, file := range []struct {
+			name string
+			data []byte
+		}{
+			{img.cfgHex, img.cfgBytes},
+			{img.layerHex, img.layerBuf},
+			{img.manHex, img.manBytes},
+		} {
+			if err := os.WriteFile(filepath.Join(tempRoot, "blobs", "sha256", file.name), file.data, 0644); err != nil {
+				return err
+			}
+		}
+
+		tagToImages[tag] = append(tagToImages[tag], img)
+	}
+
+	var topIndex ociManifest
+	topIndex.SchemaVersion = 2
+
+	for tag, imgs := range tagToImages {
+		if len(imgs) == 1 {
+			img := imgs[0]
+			desc := ociManifestDescriptor{
+				MediaType: "application/vnd.oci.image.manifest.v1+json",
+				Digest:    "sha256:" + img.manHex,
+				Size:      len(img.manBytes),
+				Annotations: map[string]string{
+					"org.opencontainers.image.ref.name": tag,
+					"io.containerd.image.name":          tag,
+				},
+			}
+			if emitPlatformForIndexManifest {
+				desc.Platform = &PlatformInfo{
+					Architecture: img.arch,
+					OS:           img.os,
+				}
+			}
+			topIndex.Manifests = append(topIndex.Manifests, desc)
+		} else {
+			var subIndex ociManifest
+			subIndex.SchemaVersion = 2
+			for _, img := range imgs {
+				subIndex.Manifests = append(subIndex.Manifests, ociManifestDescriptor{
+					MediaType: "application/vnd.oci.image.manifest.v1+json",
+					Digest:    "sha256:" + img.manHex,
+					Size:      len(img.manBytes),
+					Platform: &PlatformInfo{
+						Architecture: img.arch,
+						OS:           img.os,
+					},
+				})
+			}
+			subBytes, _ := json.Marshal(subIndex)
+			subDigest := sha256.Sum256(subBytes)
+			subHex := hex.EncodeToString(subDigest[:])
+			subPath := filepath.Join(tempRoot, "blobs", "sha256", subHex)
+			if err := os.WriteFile(subPath, subBytes, 0644); err != nil {
+				return err
+			}
+			topIndex.Manifests = append(topIndex.Manifests, ociManifestDescriptor{
+				MediaType: "application/vnd.oci.image.index.v1+json",
+				Digest:    "sha256:" + subHex,
+				Size:      len(subBytes),
+				Annotations: map[string]string{
+					"org.opencontainers.image.ref.name": tag,
+					"io.containerd.image.name":          tag,
+				},
+			})
+		}
+	}
+
+	idxBytes, _ := json.MarshalIndent(topIndex, "", "  ")
+	if err := os.WriteFile(filepath.Join(tempRoot, "index.json"), idxBytes, 0644); err != nil {
+		return err
+	}
+	layoutJSON := []byte(`{"imageLayoutVersion":"1.0.0"}`)
+	if err := os.WriteFile(filepath.Join(tempRoot, "oci-layout"), layoutJSON, 0644); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(tarFile), 0755); err != nil {
+		return err
+	}
+	f, err := os.Create(tarFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	tarw := tar.NewWriter(f)
+	defer tarw.Close()
+
+	return filepath.Walk(tempRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		relPath, err := filepath.Rel(tempRoot, path)
+		if err != nil {
+			return err
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		hdr.Name = relPath
+		if err := tarw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		_, err = io.Copy(tarw, file)
+		return err
+	})
+}
+
+func createSingleArchOCIImageFile(tarFile string, osArch string, tag string) error {
+	tempRoot, err := os.MkdirTemp("", "oci-tmp-single-")
+	if err != nil {
+		return fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tempRoot)
+
+	if err := os.MkdirAll(filepath.Join(tempRoot, "blobs", "sha256"), 0755); err != nil {
+		return err
+	}
+
+	img, err := buildArchImage(osArch, tag)
+	if err != nil {
+		return fmt.Errorf("buildArchImage failed: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(tempRoot, "blobs", "sha256", img.cfgHex), img.cfgBytes, 0644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(tempRoot, "blobs", "sha256", img.layerHex), img.layerBuf, 0644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(tempRoot, "blobs", "sha256", img.manHex), img.manBytes, 0644); err != nil {
+		return err
+	}
+
+	index := ociManifest{
+		SchemaVersion: 2,
+		Manifests: []ociManifestDescriptor{
+			{
+				MediaType: "application/vnd.oci.image.manifest.v1+json",
+				Digest:    "sha256:" + img.manHex,
+				Size:      len(img.manBytes),
+				Annotations: map[string]string{
+					"org.opencontainers.image.ref.name": tag,
+					"io.containerd.image.name":          tag,
+				},
+			},
+		},
+	}
+	idxBytes, _ := json.Marshal(index)
+	if err := os.WriteFile(filepath.Join(tempRoot, "index.json"), idxBytes, 0644); err != nil {
+		return err
+	}
+	layoutJSON := []byte(`{"imageLayoutVersion":"1.0.0"}`)
+	if err := os.WriteFile(filepath.Join(tempRoot, "oci-layout"), layoutJSON, 0644); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(tarFile), 0755); err != nil {
+		return err
+	}
+	f, err := os.Create(tarFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	tarw := tar.NewWriter(f)
+	defer tarw.Close()
+
+	return filepath.Walk(tempRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		relPath, err := filepath.Rel(tempRoot, path)
+		if err != nil {
+			return err
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		hdr.Name = relPath
+		if err := tarw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		_, err = io.Copy(tarw, file)
+		return err
+	})
+}
+
+func TestReadOsArchFromImageTarFile_DockerLegacySingleArmImage(t *testing.T) {
+	t.Parallel()
+	tempImageOutputDir, tempErr := os.MkdirTemp("", tempImageTestDir)
+	assert.NoError(t, tempErr)
+	defer os.RemoveAll(tempImageOutputDir)
+	fileName := "docker-legacy-single-arm64.tar"
+	tarPath := filepath.Join(tempImageOutputDir, fileName)
+	img := LegacyImageInput{
+		RepoTags:     []string{"example.com/docker-legacy-single:1.0.0_arm64"},
+		Config:       randomDigest("config") + ".json",
+		Architecture: "arm64",
+		OS:           "linux",
+	}
+	err := createDockerLegacyTarball(tarPath, []LegacyImageInput{img})
+	assert.NoError(t, err, fmt.Sprintf("create tarball %s failed", fileName))
+	assert.FileExistsf(t, tarPath, fmt.Sprintf("expected tarball %s not found", fileName))
+
+	archSummary, err := ReadOsArchFromImageTarFile(tarPath)
+	assert.NoError(t, err, fmt.Sprintf("read os and arch info from tarball %s failed", fileName))
+
+	assert.True(t, len(archSummary) > 0, fmt.Sprintf("tarball %s does not found any valid manifest", fileName))
+	assert.NotEmpty(t, archSummary[0].Platforms, "read platform failed")
+	assert.True(t, slices.Contains(archSummary[0].Platforms, "linux/arm64"))
+}
+
+func TestReadOsArchFromImageTarFile_DockerLegacySingleAmdImage(t *testing.T) {
+	t.Parallel()
+	tempImageOutputDir, tempErr := os.MkdirTemp("", tempImageTestDir)
+	assert.NoError(t, tempErr)
+	defer os.RemoveAll(tempImageOutputDir)
+	fileName := "docker-legacy-single-amd64.tar"
+	tarPath := filepath.Join(tempImageOutputDir, fileName)
+	img := LegacyImageInput{
+		RepoTags:     []string{"example.com/docker-legacy-single:1.0.0_amd64"},
+		Config:       randomDigest("config") + ".json",
+		Architecture: "amd64",
+		OS:           "linux",
+	}
+	err := createDockerLegacyTarball(tarPath, []LegacyImageInput{img})
+	assert.NoError(t, err, fmt.Sprintf("create tarball %s failed", fileName))
+	assert.FileExistsf(t, tarPath, fmt.Sprintf("expected tarball %s not found", fileName))
+
+	archSummary, err := ReadOsArchFromImageTarFile(tarPath)
+	assert.NoError(t, err, fmt.Sprintf("read os and arch info from tarball %s failed", fileName))
+
+	assert.True(t, len(archSummary) > 0, fmt.Sprintf("tarball %s does not found any valid manifest", fileName))
+	assert.NotEmpty(t, archSummary[0].Platforms, "read platform failed")
+	assert.True(t, slices.Contains(archSummary[0].Platforms, "linux/amd64"))
+}
+
+func TestReadOsArchFromImageTarFile_OCISingleAmdImage(t *testing.T) {
+	t.Parallel()
+	archs := "linux/amd64"
+	tag := "example.com/oci-single:1.0.0_amd64"
+	tempImageOutputDir, tempErr := os.MkdirTemp("", tempImageTestDir)
+	assert.NoError(t, tempErr)
+	defer os.RemoveAll(tempImageOutputDir)
+	fileName := "oci-single-amd64.tar"
+	tarPath := filepath.Join(tempImageOutputDir, fileName)
+
+	err := createSingleArchOCIImageFile(tarPath, archs, tag)
+	assert.NoError(t, err, fmt.Sprintf("create tarball %s failed", fileName))
+	assert.FileExistsf(t, tarPath, fmt.Sprintf("expected tarball %s not found", fileName))
+
+	archSummary, err := ReadOsArchFromImageTarFile(tarPath)
+	assert.NoError(t, err, fmt.Sprintf("read os and arch info from tarball %s failed", fileName))
+
+	assert.True(t, len(archSummary) > 0, fmt.Sprintf("tarball %s does not found any valid manifest", fileName))
+	assert.NotEmpty(t, archSummary[0].Platforms, "read platform failed")
+	assert.True(t, slices.Contains(archSummary[0].Platforms, "linux/amd64"))
+}
+
+func TestReadOsArchFromImageTarFile_OCISingleArmImage(t *testing.T) {
+	t.Parallel()
+	archs := "linux/arm64"
+	tag := "example.com/oci-single:1.0.0_arm64"
+	tempImageOutputDir, tempErr := os.MkdirTemp("", tempImageTestDir)
+	assert.NoError(t, tempErr)
+	defer os.RemoveAll(tempImageOutputDir)
+	fileName := "oci-single-arm64.tar"
+	tarPath := filepath.Join(tempImageOutputDir, fileName)
+	err := createSingleArchOCIImageFile(tarPath, archs, tag)
+	assert.NoError(t, err, fmt.Sprintf("create tarball %s failed", fileName))
+	assert.FileExistsf(t, tarPath, fmt.Sprintf("expected tarball %s not found", fileName))
+
+	archSummary, err := ReadOsArchFromImageTarFile(tarPath)
+	assert.NoError(t, err, fmt.Sprintf("read os and arch info from tarball %s failed", fileName))
+
+	assert.True(t, len(archSummary) > 0, fmt.Sprintf("tarball %s does not found any valid manifest", fileName))
+	assert.NotEmpty(t, archSummary[0].Platforms, "read platform failed")
+	assert.True(t, slices.Contains(archSummary[0].Platforms, "linux/arm64"))
+}
+
+func TestReadOsArchFromImageTarFile_OCISinglePpcImage(t *testing.T) {
+	t.Parallel()
+	archs := "linux/ppc64le"
+	tag := "example.com/oci-single:1.0.0_ppc64le"
+	tempImageOutputDir, tempErr := os.MkdirTemp("", tempImageTestDir)
+	assert.NoError(t, tempErr)
+	defer os.RemoveAll(tempImageOutputDir)
+	fileName := "oci-single-ppc64le.tar"
+	tarPath := filepath.Join(tempImageOutputDir, fileName)
+	err := createSingleArchOCIImageFile(tarPath, archs, tag)
+	assert.NoError(t, err, fmt.Sprintf("create tarball %s failed", fileName))
+	assert.FileExistsf(t, tarPath, fmt.Sprintf("expected tarball %s not found", fileName))
+
+	archSummary, err := ReadOsArchFromImageTarFile(tarPath)
+	assert.NoError(t, err, fmt.Sprintf("read os and arch info from tarball %s failed", fileName))
+
+	assert.True(t, len(archSummary) > 0, fmt.Sprintf("tarball %s does not found any valid manifest", fileName))
+	assert.NotEmpty(t, archSummary[0].Platforms, "read platform failed")
+	assert.True(t, slices.Contains(archSummary[0].Platforms, "linux/ppc64le"))
+}
+
+func TestReadOsArchFromImageTarFile_OCISingleTarGzipImage(t *testing.T) {
+	t.Parallel()
+	archs := "linux/arm64"
+	tag := "example.com/oci-single-tar-gz:1.0.0_arm64"
+	tempImageOutputDir, tempErr := os.MkdirTemp("", tempImageTestDir)
+	assert.NoError(t, tempErr)
+	defer os.RemoveAll(tempImageOutputDir)
+	fileName := "oci-single-tar-gz-arm64.tar"
+	tarPath := filepath.Join(tempImageOutputDir, fileName)
+	err := createSingleArchOCIImageFile(tarPath, archs, tag)
+	assert.NoError(t, err, fmt.Sprintf("create tarball %s failed", fileName))
+	assert.FileExistsf(t, tarPath, fmt.Sprintf("expected tarball %s not found", fileName))
+
+	tarFile, _ := os.Open(tarPath)
+	defer tarFile.Close()
+
+	gzfileName := "oci-single-tar-gz-arm64.tar.gz"
+	tarGzPath := filepath.Join(tempImageOutputDir, gzfileName)
+	gzFile, err := os.Create(tarGzPath)
+	assert.NoError(t, err, fmt.Sprintf("create gzip file %s failed", gzfileName))
+	defer gzFile.Close()
+
+	gzWriter := gzip.NewWriter(gzFile)
+	defer gzWriter.Close()
+
+	_, err = io.Copy(gzWriter, tarFile)
+	assert.NoError(t, err, fmt.Sprintf("copy tar file into %s failed", gzfileName))
+	err = gzWriter.Close()
+	assert.NoError(t, err, fmt.Sprintf("close gzip writer for %s failed", gzfileName))
+	archSummary, err := ReadOsArchFromImageTarFile(tarPath)
+	assert.NoError(t, err, fmt.Sprintf("read os and arch info from tarball %s failed", gzfileName))
+
+	assert.True(t, len(archSummary) > 0, fmt.Sprintf("tarball %s does not found any valid manifest", gzfileName))
+	assert.NotEmpty(t, archSummary[0].Platforms, "read platform failed")
+	assert.True(t, slices.Contains(archSummary[0].Platforms, "linux/arm64"))
+}
+
+func TestReadOsArchFromImageTarFile_OCIMultiArch(t *testing.T) {
+	t.Parallel()
+	archs := [][]string{
+		{"linux/amd64", "example.com/oci-multi-arch:1.0.0"},
+		{"linux/arm64", "example.com/oci-multi-arch:1.0.0"},
+	}
+	tempImageOutputDir, tempErr := os.MkdirTemp("", tempImageTestDir)
+	assert.NoError(t, tempErr)
+	defer os.RemoveAll(tempImageOutputDir)
+	fileName := "oci-multi-arch.tar"
+	tarPath := filepath.Join(tempImageOutputDir, fileName)
+	err := createMultiArchOCIImageFile(tarPath, archs, false)
+	assert.NoError(t, err, fmt.Sprintf("create tarball %s failed", fileName))
+	assert.FileExistsf(t, tarPath, fmt.Sprintf("expected tarball %s not found", fileName))
+
+	archSummary, err := ReadOsArchFromImageTarFile(tarPath)
+	assert.NoError(t, err, fmt.Sprintf("read os and arch info from tarball %s failed", fileName))
+
+	assert.True(t, len(archSummary) > 0, fmt.Sprintf("tarball %s does not found any valid manifest", fileName))
+	assert.NotEmpty(t, archSummary[0].Platforms, "read platform failed")
+	assert.True(t, slices.Contains(archSummary[0].Platforms, "linux/amd64") && slices.Contains(archSummary[0].Platforms, "linux/arm64"))
+
+}
+
+func TestReadOsArchFromImageTarFile_OCIMultiImage(t *testing.T) {
+	t.Parallel()
+	archs := [][]string{
+		{"linux/amd64", "example.com/oci-multi-image:1.0.0"},
+		{"linux/arm64", "example.com/oci-multi-image:1.0.0"},
+		{"linux/amd64", "example.com/oci-multi-image:1.0.1"},
+	}
+	tempImageOutputDir, tempErr := os.MkdirTemp("", tempImageTestDir)
+	assert.NoError(t, tempErr)
+	defer os.RemoveAll(tempImageOutputDir)
+	fileName := "oci-muti-image.tar"
+	tarPath := filepath.Join(tempImageOutputDir, fileName)
+	err := createMultiArchOCIImageFile(tarPath, archs, false)
+	assert.NoError(t, err, fmt.Sprintf("create tarball %s failed", fileName))
+	assert.FileExistsf(t, tarPath, fmt.Sprintf("expected tarball %s not found", fileName))
+
+	archSummary, err := ReadOsArchFromImageTarFile(tarPath)
+	assert.NoError(t, err, fmt.Sprintf("read os and arch info from tarball %s failed", fileName))
+
+	assert.True(t, len(archSummary) > 0, fmt.Sprintf("tarball %s does not found any valid manifest", fileName))
+	assert.True(t, len(archSummary) == 2, fmt.Sprintf("tarball %s should contains two image repo tags", fileName))
+	assert.NotEmpty(t, archSummary[0].Platforms, "read platform failed")
+}
+
+func TestReadOsArchFromImageTarFile_DockerLegacyMultiImage(t *testing.T) {
+	t.Parallel()
+	firstImage := LegacyImageInput{
+		RepoTags:     []string{"example.com/legacy-multi-image:1.0"},
+		Config:       randomDigest("firstImage-config") + ".json",
+		OS:           "linux",
+		Architecture: "amd64",
+	}
+	secondImage := LegacyImageInput{
+		RepoTags:     []string{"example.com/legacy-multi-image:2.0"},
+		Config:       randomDigest("secondImage-config") + ".json",
+		OS:           "linux",
+		Architecture: "amd64",
+	}
+	tempImageOutputDir, tempErr := os.MkdirTemp("", tempImageTestDir)
+	assert.NoError(t, tempErr)
+	defer os.RemoveAll(tempImageOutputDir)
+	fileName := "legacy-muti-image.tar"
+	tarPath := filepath.Join(tempImageOutputDir, fileName)
+	err := createDockerLegacyTarball(tarPath, []LegacyImageInput{firstImage, secondImage})
+	assert.NoError(t, err, fmt.Sprintf("create tarball %s failed", fileName))
+	assert.FileExistsf(t, tarPath, fmt.Sprintf("expected tarball %s not found", fileName))
+
+	archSummary, err := ReadOsArchFromImageTarFile(tarPath)
+	assert.NoError(t, err, fmt.Sprintf("read os and arch info from tarball %s failed", fileName))
+
+	assert.True(t, len(archSummary) > 0, fmt.Sprintf("tarball %s does not found any valid manifest", fileName))
+	assert.True(t, len(archSummary) == 2, fmt.Sprintf("tarball %s should contains two image repo tags", fileName))
+	assert.NotEmpty(t, archSummary[0].Platforms, "read platform failed")
+}
+
+func TestValidateArch_SingleArchSupported(t *testing.T) {
+	t.Parallel()
+	var arch, fileName, tarPath, tag, currentPlatform string
+	currentPlatform = "linux/arm64"
+
+	arch = "linux/arm64"
+	tag = "example.com/oci-single:1.0.0_arm64"
+	tempArmImageOutputDir, tempErr := os.MkdirTemp("", tempImageTestDir)
+	assert.NoError(t, tempErr)
+	defer os.RemoveAll(tempArmImageOutputDir)
+	fileName = "oci-single-arm64.tar"
+	tarPath = filepath.Join(tempArmImageOutputDir, fileName)
+	createArmImageErr := createSingleArchOCIImageFile(tarPath, arch, tag)
+	assert.NoError(t, createArmImageErr, fmt.Sprintf("create tarball %s failed", fileName))
+	assert.FileExistsf(t, tarPath, fmt.Sprintf("expected tarball %s not found", fileName))
+
+	unsupportedErr := ValidateArch(tarPath, currentPlatform)
+	assert.NoError(t, unsupportedErr, fmt.Sprintf("validate os/arch from tarfile %s failed", fileName))
+}
+
+func TestValidateArch_SingleArchUnsupported(t *testing.T) {
+	t.Parallel()
+	var arch, fileName, tarPath, tag, currentPlatform string
+	currentPlatform = "linux/arm64"
+
+	arch = "linux/amd64"
+	tag = "example.com/oci-single:1.0.0_amd64"
+	tempAmdImageOutputDir, tempErr := os.MkdirTemp("", tempImageTestDir)
+	assert.NoError(t, tempErr)
+	defer os.RemoveAll(tempAmdImageOutputDir)
+	fileName = "oci-single-amd64.tar"
+	tarPath = filepath.Join(tempAmdImageOutputDir, fileName)
+	createAmdImageErr := createSingleArchOCIImageFile(tarPath, arch, tag)
+	assert.NoError(t, createAmdImageErr, fmt.Sprintf("create tarball %s failed", fileName))
+	assert.FileExistsf(t, tarPath, fmt.Sprintf("expected tarball %s not found", fileName))
+
+	unsupportedErr := ValidateArch(tarPath, currentPlatform)
+	t.Logf("unsupportedErr: %v", unsupportedErr)
+	if _, ok := unsupportedErr.(*TarfileOsArchUnsupportedError); !ok {
+		assert.Fail(t, "validate os/arch from tarfile %s failed, error should be of type *TarfileOsArchUnsupportedError")
+	}
+}
+
+func TestValidateArch_MultiArchSupported(t *testing.T) {
+	t.Parallel()
+	var fileName, tarPath, currentPlatform string
+	currentPlatform = "linux/amd64"
+
+	archs := [][]string{
+		{"linux/amd64", "example.com/oci-multi-arch:1.0.0"},
+		{"linux/arm64", "example.com/oci-multi-arch:1.0.0"},
+	}
+	tempImageOutputDir, tempErr := os.MkdirTemp("", tempImageTestDir)
+	assert.NoError(t, tempErr)
+	defer os.RemoveAll(tempImageOutputDir)
+	fileName = "oci-multi-arch.tar"
+	tarPath = filepath.Join(tempImageOutputDir, fileName)
+	err := createMultiArchOCIImageFile(tarPath, archs, false)
+	assert.NoError(t, err, fmt.Sprintf("create tarball %s failed", fileName))
+	assert.FileExistsf(t, tarPath, fmt.Sprintf("expected tarball %s not found", fileName))
+
+	unsupportedErr := ValidateArch(tarPath, currentPlatform)
+	assert.NoError(t, unsupportedErr, fmt.Sprintf("validate os/arch from tarfile %s failed", fileName))
+
+}
+
+func TestValidateArch_MultiArchUnSupported(t *testing.T) {
+	t.Parallel()
+	var fileName, tarPath, currentPlatform string
+	currentPlatform = "linux/amd64"
+
+	archs := [][]string{
+		{"linux/ppc64le", "example.com/oci-multi-arch:1.0.0"},
+		{"linux/arm64", "example.com/oci-multi-arch:1.0.0"},
+	}
+	tempImageOutputDir, tempErr := os.MkdirTemp("", tempImageTestDir)
+	assert.NoError(t, tempErr)
+	defer os.RemoveAll(tempImageOutputDir)
+	fileName = "oci-multi-arch.tar"
+	tarPath = filepath.Join(tempImageOutputDir, fileName)
+	err := createMultiArchOCIImageFile(tarPath, archs, false)
+	assert.NoError(t, err, fmt.Sprintf("create tarball %s failed", fileName))
+	assert.FileExistsf(t, tarPath, fmt.Sprintf("expected tarball %s not found", fileName))
+
+	unsupportedErr := ValidateArch(tarPath, currentPlatform)
+	assert.Error(t, unsupportedErr, "expected an error but got none")
+	t.Logf("unsupportedErr: %v", unsupportedErr)
+	if _, ok := unsupportedErr.(*TarfileOsArchUnsupportedError); !ok {
+		assert.Fail(t, "validate os/arch from tarfile %s failed, error should be of type *TarfileOsArchUnsupportedError")
+	}
+}
+func TestValidateArch_MultiImage(t *testing.T) {
+	t.Parallel()
+	var fileName, tarPath, currentPlatform string
+	currentPlatform = "linux/amd64"
+
+	archs := [][]string{
+		{"linux/amd64", "example.com/oci-multi-arch:1.0.0"},
+		{"linux/amd64", "example.com/oci-multi-arch:2.0.0"},
+	}
+	tempImageOutputDir, tempErr := os.MkdirTemp("", tempImageTestDir)
+	assert.NoError(t, tempErr)
+	defer os.RemoveAll(tempImageOutputDir)
+	fileName = "oci-multi-arch.tar"
+	tarPath = filepath.Join(tempImageOutputDir, fileName)
+	err := createMultiArchOCIImageFile(tarPath, archs, false)
+	assert.NoError(t, err, fmt.Sprintf("create tarball %s failed", fileName))
+	assert.FileExistsf(t, tarPath, fmt.Sprintf("expected tarball %s not found", fileName))
+
+	unsupportedErr := ValidateArch(tarPath, currentPlatform)
+	assert.Error(t, unsupportedErr, "expected an error but got none")
+	t.Logf("unsupportedErr: %v", unsupportedErr)
+	if _, ok := unsupportedErr.(*TarfileOsArchUnsupportedError); !ok {
+		assert.Fail(t, "validate os/arch from tarfile %s failed, error should be of type *TarfileOsArchUnsupportedError")
+	}
+}


### PR DESCRIPTION
 - ^TestReadOsArchFromImageTarFile 测试生成镜像tar包(OCI-amd64/arm64, 低版本docker-amd64/arm64, OCI多架构, OCI/docker多镜像等8种场景), 因生成tar会删除文件, 所以本地临时注释删除代码, 记录了生成镜像的结果(通过ctr验证), 证明截图附加在issue中
  - ^TestValidateArch 测试单架构/多架构/多镜像共5种场景
  - 限制了tar包中只允许包含一个镜像
  - 因为 LoadImage 之前的校验, 这个过程比较独立也比较简单, 通过 TestValidateArch 可以校验出来, 所以没有修改 LoadImage 方法
[20250716-OSCP-733-附加测试.pdf](https://github.com/user-attachments/files/21300903/20250716-OSCP-733-.pdf)
