### PR TITLE
bugfix grpc_interceptor.go

### DIFF
--- a/pkg/web/interceptor/grpc_interceptor.go
+++ b/pkg/web/interceptor/grpc_interceptor.go
@@ -197,7 +197,7 @@ func UnaryRecoverInterceptor(errorCode pberrorcode.ErrorCode) grpc.UnaryServerIn
 		defer func() {
 			if r := recover(); r != nil {
 				nlog.Errorf("[%s] Recovered from panic: %+v, stack: %s", info.FullMethod, r, debug.Stack())
-				wrappedErr := fmt.Errorf("%s", r)
+				wrappedErr := fmt.Errorf("%+v", r)
 				resp = &v1alpha1.ErrorResponse{
 					Status: &v1alpha1.Status{
 						Code:    int32(errorCode),
@@ -218,7 +218,7 @@ func StreamRecoverInterceptor(errorCode pberrorcode.ErrorCode) grpc.StreamServer
 		defer func() {
 			if r := recover(); r != nil {
 				nlog.Errorf("[%s] Recovered from panic: %+v, stack: %s", info.FullMethod, r, debug.Stack())
-				wrappedErr := fmt.Errorf("%s", r)
+				wrappedErr := fmt.Errorf("%+v", r)
 				resp := &v1alpha1.ErrorResponse{
 					Status: &v1alpha1.Status{
 						Code:    int32(errorCode),


### PR DESCRIPTION
%s只能输出值的基本字符串表示，对于结构体、切片、map等复杂类型， 只输出类型名或内存地址，丢失了原始类型信息，并且与日志输出格式也不同，错误较为明显