### PR TITLE
feat：kuscia支持达梦数据源（#739）

### DIFF
--- a/etc/conf/kuscia.yaml
+++ b/etc/conf/kuscia.yaml
@@ -88,6 +88,7 @@ dataMesh:
       dataSourceTypes:                # the type of datasource that data proxy supported
         - "odps"                      # odps also call as Aliyun MaxCompute
         - "hive"
+        - "dameng"                    # dameng database
 # Note: Currently only a single odps data source configuration is supported. If two odps configurations are defined here, the latter one will override the previous one.
 #   - endpoint: "example-dataproxy-grpc:8024"
 #     dataSourceTypes:

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -229,6 +229,7 @@ const (
 	DomainDataSourceTypeODPS           = "odps"
 	DomainDataSourceTypePostgreSQL     = "postgresql"
 	DomainDataSourceTypeHive           = "hive"
+	DomainDataSourceTypeDameng         = "dameng"
 	DefaultDomainDataSourceLocalFSPath = "var/storage/data"
 )
 

--- a/pkg/datamesh/metaserver/service/domaindatasource.go
+++ b/pkg/datamesh/metaserver/service/domaindatasource.go
@@ -221,6 +221,7 @@ func parseDataSourceURI(sourceType string, info *datamesh.DataSourceInfo) (uri s
 	case common.DomainDataSourceTypeMysql:
 	case common.DomainDataSourceTypePostgreSQL:
 	case common.DomainDataSourceTypeHive:
+	case common.DomainDataSourceTypeDameng:
 		if isInvalid(info.Database == nil) {
 			return
 		}
@@ -231,7 +232,7 @@ func parseDataSourceURI(sourceType string, info *datamesh.DataSourceInfo) (uri s
 		}
 		uri = info.Odps.Endpoint + "/" + info.Odps.Project
 	default:
-		err = fmt.Errorf("datasource type:%q not support, only support [localfs,oss,mysql,odps,postgresql,hive]", sourceType)
+		err = fmt.Errorf("datasource type:%q not support, only support [localfs,oss,mysql,odps,postgresql,hive,dameng]", sourceType)
 		nlog.Error(err)
 		return
 	}
@@ -285,6 +286,7 @@ func decodeDataSourceInfo(sourceType string, connectionStr string) (*datamesh.Da
 	case common.DomainDataSourceTypeMysql:
 	case common.DomainDataSourceTypePostgreSQL:
 	case common.DomainDataSourceTypeHive:
+	case common.DomainDataSourceTypeDameng:
 		dsInfo.Database = &datamesh.DatabaseDataSourceInfo{}
 		err = json.Unmarshal(connectionBytes, dsInfo.Database)
 	case common.DomainDataSourceTypeLocalFS:

--- a/pkg/datamesh/metaserver/service/domaindatasource_test.go
+++ b/pkg/datamesh/metaserver/service/domaindatasource_test.go
@@ -70,6 +70,19 @@ func makeDomainDataSourceService(t *testing.T, conf *config.DataMeshConfig) IDom
 	return NewDomainDataSourceService(conf, makeConfigService(t))
 }
 
+func TestParseDataSourceURI_UnsupportedType(t *testing.T) {
+	info := &datamesh.DataSourceInfo{
+		Localfs: &datamesh.LocalDataSourceInfo{
+			Path: "/test/path",
+		},
+	}
+	uri, err := parseDataSourceURI("unsupported_type", info)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not support")
+	assert.Contains(t, err.Error(), "unsupported_type")
+	assert.Empty(t, uri)
+}
+
 func makeConfigService(t *testing.T) cmservice.IConfigService {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	assert.Nil(t, err)

--- a/pkg/kusciaapi/service/domaindata_source.go
+++ b/pkg/kusciaapi/service/domaindata_source.go
@@ -492,8 +492,9 @@ func validateDataSourceType(t string) error {
 		t != common.DomainDataSourceTypeLocalFS &&
 		t != common.DomainDataSourceTypeODPS &&
 		t != common.DomainDataSourceTypePostgreSQL &&
-		t != common.DomainDataSourceTypeHive {
-		return fmt.Errorf("domain data source type %q doesn't support, the available types are [localfs,oss,mysql,odps,postgresql,hive]", t)
+		t != common.DomainDataSourceTypeHive &&
+		t != common.DomainDataSourceTypeDameng {
+		return fmt.Errorf("domain data source type %q doesn't support, the available types are [localfs,oss,mysql,odps,postgresql,hive,dameng]", t)
 	}
 	return nil
 }
@@ -595,7 +596,7 @@ func decodeDataSourceInfo(sourceType string, connectionStr string) (*kusciaapi.D
 	case common.DomainDataSourceTypeOSS:
 		dsInfo.Oss = &kusciaapi.OssDataSourceInfo{}
 		err = json.Unmarshal(connectionBytes, dsInfo.Oss)
-	case common.DomainDataSourceTypeMysql, common.DomainDataSourceTypePostgreSQL, common.DomainDataSourceTypeHive:
+	case common.DomainDataSourceTypeMysql, common.DomainDataSourceTypePostgreSQL, common.DomainDataSourceTypeHive, common.DomainDataSourceTypeDameng:
 		dsInfo.Database = &kusciaapi.DatabaseDataSourceInfo{}
 		err = json.Unmarshal(connectionBytes, dsInfo.Database)
 	case common.DomainDataSourceTypeLocalFS:
@@ -649,7 +650,7 @@ func parseAndNormalizeDataSource(sourceType string, info *kusciaapi.DataSourceIn
 		// truncate slash
 		info.Localfs.Path = strings.TrimRight(info.Localfs.Path, string(filepath.Separator))
 		uri = info.Localfs.Path
-	case common.DomainDataSourceTypeMysql, common.DomainDataSourceTypePostgreSQL, common.DomainDataSourceTypeHive:
+	case common.DomainDataSourceTypeMysql, common.DomainDataSourceTypePostgreSQL, common.DomainDataSourceTypeHive, common.DomainDataSourceTypeDameng:
 		if isInvalid(info.Database == nil) {
 			return
 		}
@@ -660,7 +661,7 @@ func parseAndNormalizeDataSource(sourceType string, info *kusciaapi.DataSourceIn
 		}
 		uri = info.Odps.Endpoint + "/" + info.Odps.Project
 	default:
-		err = fmt.Errorf("datasource type:%q not support, only support [localfs,oss,mysql,odps,postgresql,hive]", sourceType)
+		err = fmt.Errorf("datasource type:%q not support, only support [localfs,oss,mysql,odps,postgresql,hive,dameng]", sourceType)
 		nlog.Error(err)
 		return
 	}
@@ -701,6 +702,7 @@ func validateDataSourceInfo(sourceType string, info *kusciaapi.DataSourceInfo) e
 	case common.DomainDataSourceTypeMysql:
 	case common.DomainDataSourceTypePostgreSQL:
 	case common.DomainDataSourceTypeHive:
+	case common.DomainDataSourceTypeDameng:
 		if info.Database == nil {
 			return fmt.Errorf("%v info is nil", sourceType)
 		}

--- a/scripts/deploy/kuscia.sh
+++ b/scripts/deploy/kuscia.sh
@@ -648,7 +648,9 @@ function dataproxy_config() {
   dataProxyList:
     - endpoint: "dataproxy-grpc:8023"
       dataSourceTypes:
-        - "odps"'
+        - "odps"
+        - "hive"
+        - "dameng"'
   if ! grep -q "${data_proxy_config}" "${kuscia_config_file}"; then
      echo "${data_proxy_config}" >> "${kuscia_config_file}"
   fi


### PR DESCRIPTION
kuscia支持达梦数据源（具体实现在dataproxy），但是kuscia也需要配套进行少量修改。
具体issue：https://github.com/secretflow/kuscia/issues/739