### PR TITLE
fix: allow consecutive dots in archive filenames

### DIFF
--- a/pkg/utils/assist/archive.go
+++ b/pkg/utils/assist/archive.go
@@ -138,7 +138,7 @@ func Untar(dst string, isGzip bool, adjustLink bool, r io.Reader, skipUnNormalFi
 
 		// Clean and validate the file path to prevent directory traversal
 		cleanName := filepath.Clean(header.Name)
-		if strings.Contains(cleanName, "..") {
+		if cleanName == ".." || strings.HasPrefix(cleanName, ".."+string(filepath.Separator)) {
 			return fmt.Errorf("invalid file path in tar archive: %s contains directory traversal attempt", header.Name)
 		}
 
@@ -146,7 +146,7 @@ func Untar(dst string, isGzip bool, adjustLink bool, r io.Reader, skipUnNormalFi
 
 		// Ensure the target path is within the destination directory
 		relPath, err := filepath.Rel(dst, target)
-		if err != nil || strings.HasPrefix(relPath, "..") {
+		if err != nil || relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
 			return fmt.Errorf("invalid file path in tar archive: %s escapes destination directory", header.Name)
 		}
 

--- a/pkg/utils/assist/archive_names_test.go
+++ b/pkg/utils/assist/archive_names_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Ant Group Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package assist
+
+import (
+	"archive/tar"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUntarDotFilenames(t *testing.T) {
+	for _, name := range []string{"file.txt", "model..json", "..data", ".../config", "nested/model..json"} {
+		t.Run(name, func(t *testing.T) {
+			var archive bytes.Buffer
+			writer := tar.NewWriter(&archive)
+			require.NoError(t, writer.WriteHeader(&tar.Header{Name: name, Mode: 0600, Size: 4}))
+			_, err := writer.Write([]byte("data"))
+			require.NoError(t, err)
+			require.NoError(t, writer.Close())
+			destination := t.TempDir()
+			require.NoError(t, Untar(destination, false, false, &archive, false))
+			content, err := os.ReadFile(filepath.Join(destination, name))
+			require.NoError(t, err)
+			require.Equal(t, "data", string(content))
+		})
+	}
+}
+
+func TestUntarRejectsParentDirectory(t *testing.T) {
+	for _, name := range []string{"../outside", "nested/../../outside"} {
+		t.Run(name, func(t *testing.T) {
+			var archive bytes.Buffer
+			writer := tar.NewWriter(&archive)
+			require.NoError(t, writer.WriteHeader(&tar.Header{Name: name, Mode: 0600, Size: 4}))
+			_, err := writer.Write([]byte("data"))
+			require.NoError(t, err)
+			require.NoError(t, writer.Close())
+			root := t.TempDir()
+			require.Error(t, Untar(filepath.Join(root, "destination"), false, false, &archive, false))
+			require.NoFileExists(t, filepath.Join(root, "outside"))
+		})
+	}
+}


### PR DESCRIPTION
Untar treats any occurrence of `..` in a filename as directory traversal. As a result, a layer containing `model..json`, `..data`, or `.../config` cannot be extracted through RawMounter. The destination-relative check also rejects names beginning with two dots.

Check for the parent-directory component instead of a substring in both places. The regression tests extract legitimate filenames and verify that `../outside` and `nested/../../outside` are still rejected without writing outside the destination.

Validation on Linux with Go 1.24.7: the filename regression fails on the unchanged implementation and passes with this change; `go test -race` for assist and paths, the image mounter package tests, and `go vet` for assist and paths pass. Existing whole-package coverage is 43.2% for assist and 35.1% for paths; this is not a full-repository test run. [Validation run](https://github.com/Hanabi9248/kuscia/actions/runs/34691839549).